### PR TITLE
chore: add parametrized submitTest, drop blockfrost client fallbacks

### DIFF
--- a/src/blockfrost-client.ts
+++ b/src/blockfrost-client.ts
@@ -1,8 +1,7 @@
-import { BlockFrostAPI, BlockfrostServerError } from '@blockfrost/blockfrost-js';
+import { BlockFrostAPI } from '@blockfrost/blockfrost-js';
+import { getConfig } from './config.js';
 
-const projectId = process.env.PROJECT_ID;
-const serverUrl = process.env.SERVER_URL as string;
-const fallbackServerUrl = process.env.FALLBACK_SERVER_URL;
+const { projectId, serverUrl } = getConfig();
 
 if (!projectId) {
   throw new Error('PROJECT_ID env is required');
@@ -12,80 +11,10 @@ if (!serverUrl) {
   throw new Error('SERVER_URL env is required');
 }
 
-export const getPrimaryInstance = (): BlockFrostAPI => {
+export const getBlockfrostAPIClient = (): BlockFrostAPI => {
   return new BlockFrostAPI({
     projectId,
     customBackend: serverUrl,
     gotOptions: { https: { rejectUnauthorized: false } },
   });
 };
-
-export const getSecondaryInstance = (): BlockFrostAPI => {
-  if (fallbackServerUrl) {
-    return new BlockFrostAPI({
-      projectId,
-      customBackend: fallbackServerUrl,
-      gotOptions: { https: { rejectUnauthorized: false } },
-    });
-  }
-
-  // Fallback to standard public Blockfrost API
-  return new BlockFrostAPI({ projectId });
-};
-
-async function callWithFallback<T>(
-  apiCall: (instance: BlockFrostAPI) => Promise<T>,
-  name: string,
-): Promise<T> {
-  const primary = getPrimaryInstance();
-  const primaryUrl = serverUrl;
-
-  console.log(`[Attempt 1] Fetching ${name} from PRIMARY (${primaryUrl})`);
-
-  try {
-    const result = await apiCall(primary);
-
-    console.log(`✓ SUCCESS: Fetched ${name} from PRIMARY`);
-    return result;
-  } catch (primaryError) {
-    console.warn(`! FAILURE: Could not fetch ${name} from PRIMARY.`, primaryError);
-  }
-
-  const secondary = getSecondaryInstance();
-  const secondaryUrl = fallbackServerUrl || 'Public Blockfrost API';
-
-  console.log(`[Attempt 2] Fetching ${name} from SECONDARY (${secondaryUrl})`);
-
-  try {
-    const result = await apiCall(secondary);
-
-    console.log(`SUCCESS: Fetched ${name} from SECONDARY`);
-    return result;
-  } catch (secondaryError) {
-    console.error(`FAILED: Could not fetch ${name} from SECONDARY.`, secondaryError);
-    // Both attempts failed
-    throw secondaryError;
-  }
-}
-
-export const getEpochsLatestParameters = () =>
-  callWithFallback(instance => instance.epochsLatestParameters(), 'epochs latest parameters');
-
-export const getEpochsLatest = () =>
-  callWithFallback(instance => instance.epochsLatest(), 'epochs latest');
-
-export const getLatestBlock = () =>
-  callWithFallback(instance => instance.blocksLatest(), 'latest block');
-
-export const getAddressUtxos = (address: string) =>
-  callWithFallback(async instance => {
-    try {
-      return await instance.addressesUtxosAll(address);
-    } catch (error) {
-      if (error instanceof BlockfrostServerError && error.status_code === 404) {
-        // Address unused, return empty array
-        return [];
-      }
-      throw error;
-    }
-  }, `address UTXOs for ${address}`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,18 @@
+export const getConfig = () => {
+  const projectId = process.env.PROJECT_ID;
+  const serverUrl = process.env.SERVER_URL || 'http://localhost:3000';
+  const network = process.env.NETWORK;
+  const environment = (process.env.TEST_ENV ?? 'dev') as 'prod' | 'dev';
+  const submitMnemonic: string | undefined = process.env.SUBMIT_MNEMONIC;
+  const blockchainStateSetup =
+    process.env.BLOCKCHAIN_STATE_SETUP === 'true' || process.env.BLOCKCHAIN_STATE_SETUP === '1';
+
+  return {
+    projectId,
+    serverUrl,
+    network,
+    environment,
+    submitMnemonic,
+    blockchainStateSetup,
+  };
+};

--- a/src/fixtures/preprod/tx/submit.ts
+++ b/src/fixtures/preprod/tx/submit.ts
@@ -1,5 +1,6 @@
 import { expect } from 'vitest';
 import { submitTest } from '../../../tx-builder/test.js';
+import { Fixture } from '../../../types/index.js';
 
 export default [
   {
@@ -8,7 +9,8 @@ export default [
     endpoints: ['tx/submit'],
     customTimeout: 180_000,
     retry: 2,
-    customTest: async () => await submitTest('preprod'),
+    customTest: async (_endpoint, _client, customTestParams) =>
+      await submitTest('preprod', customTestParams),
   },
   {
     id: 'tx-submit-valid-cbor_65373de66591',
@@ -41,4 +43,4 @@ export default [
       status_code: 400,
     },
   },
-];
+] as Fixture[];

--- a/src/fixtures/preview/tx/submit.ts
+++ b/src/fixtures/preview/tx/submit.ts
@@ -1,5 +1,6 @@
 import { submitTest } from '../../../tx-builder/test.js';
 import { expect } from 'vitest';
+import { Fixture } from '../../../types/index.js';
 
 export default [
   {
@@ -8,7 +9,8 @@ export default [
     endpoints: ['tx/submit'],
     customTimeout: 180_000,
     retry: 2,
-    customTest: async () => await submitTest('preview'),
+    customTest: async (_endpoint, _client, customTestParams) =>
+      await submitTest('preview', customTestParams),
   },
   {
     id: 'tx-submit-valid-cbor_65373de66591',
@@ -42,4 +44,4 @@ export default [
       status_code: 400,
     },
   },
-];
+] as Fixture[];

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -1,6 +1,7 @@
 import { expect } from 'vitest';
 import { getUnixTime, isValid } from 'date-fns';
 import { isBlockchainStateSetupEnabled } from './utils.js';
+import { getConfig } from './config.js';
 
 type BigValue = string | number | bigint;
 
@@ -290,7 +291,7 @@ export const toBeAssetUnit = (received: string) => {
 };
 
 export const toBeStakeAddress = (received: string) => {
-  const stakeAddrPrefix = process.env.NETWORK === 'mainnet' ? 'stake1' : 'stake_test1';
+  const stakeAddrPrefix = getConfig().network === 'mainnet' ? 'stake1' : 'stake_test1';
 
   return {
     pass: typeof received === 'string' && received.startsWith(stakeAddrPrefix),

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,6 +1,6 @@
 import { expect } from 'vitest';
 import * as jestExtendedMatchers from 'jest-extended';
-import { getEpochsLatest, getLatestBlock } from './blockfrost-client.js';
+import { getBlockfrostAPIClient } from './blockfrost-client.js';
 import {
   toBeBlake2b256Hash,
   toBePoolBech32,
@@ -31,7 +31,8 @@ export const setGlobalBlockchainState = async (options?: { force?: boolean }) =>
   }
 
   try {
-    const [epoch, block] = await Promise.all([getEpochsLatest(), getLatestBlock()]);
+    const client = getBlockfrostAPIClient();
+    const [epoch, block] = await Promise.all([client.epochsLatest(), client.blocksLatest()]);
 
     globalThis.latest = {
       block,

--- a/src/tx-builder/helpers/compose-transaction.ts
+++ b/src/tx-builder/helpers/compose-transaction.ts
@@ -3,12 +3,25 @@ import * as CardanoWasm from '@emurgo/cardano-serialization-lib-nodejs';
 import { UTXO } from '../types/index.js';
 import { Responses } from '@blockfrost/blockfrost-js';
 
+export interface BlockchainParameters {
+  protocolParams: Pick<
+    Responses['epoch_param_content'],
+    | 'min_fee_a'
+    | 'min_fee_b'
+    | 'pool_deposit'
+    | 'key_deposit'
+    | 'coins_per_utxo_size'
+    | 'max_val_size'
+    | 'max_tx_size'
+  >;
+  currentSlot: number;
+}
 export const composeTransaction = (
   address: string,
   outputAddress: string,
   outputAmount: string,
   utxos: UTXO,
-  params: { protocolParams: Responses['epoch_param_content']; currentSlot: number },
+  params: BlockchainParameters,
 ): {
   txHash: string;
   txBody: CardanoWasm.TransactionBody;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,6 +3,7 @@ import { TestOptions } from 'vitest';
 import { Options, Got } from 'got';
 
 export type Fixture = {
+  id: string;
   testName: string;
   customTimeout?: TestOptions['timeout'];
   // Times to retry the test if fails. Useful for making flaky tests more stable.
@@ -13,6 +14,11 @@ export type Fixture = {
   postBody?: Options['body'];
   headers?: Options['headers'];
   clientOptions?: Options;
-  customTest?: (endpoint: string, client: Got) => Promise<void>;
+  customTest?: (
+    endpoint: string,
+    client: Got,
+    customTestParams?: Record<string, unknown>,
+  ) => Promise<void>;
   customExpect?: (response: unknown | null) => Promise<void>;
+  customTestParams?: Record<string, unknown>;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { getConfig } from './config.js';
+
 export const normalizePath = (pathStr: string) => {
   // 1. query params
   let normalized = pathStr.split(/[?#]/)[0];
@@ -17,7 +19,7 @@ export const normalizePath = (pathStr: string) => {
 };
 
 export const isBlockchainStateSetupEnabled = () => {
-  return (
-    process.env.BLOCKCHAIN_STATE_SETUP === 'true' || process.env.BLOCKCHAIN_STATE_SETUP === '1'
-  );
+  const envConfig = getConfig();
+
+  return envConfig.blockchainStateSetup;
 };

--- a/vitest.config.integration.ts
+++ b/vitest.config.integration.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vitest/config';
 
 if (!['mainnet', 'preprod', 'preview'].includes(process.env.NETWORK || '')) {
-  throw 'Error NETWORK env variable can be only `mainnet, preview, preprod, ipfs, milkomeda-mainnet, milkomeda-testnet`';
+  throw 'Error NETWORK env variable can be only mainnet, preview or preprod.';
 }
 
 const testFolders = [`./src/tests/${process.env.NETWORK}/**/*.ts`, `./src/tests/common/**/*.ts`];


### PR DESCRIPTION
```ts
/**
 * Submits a transaction and verifies it gets included in a block.
 *
 * @param network - Target network: 'mainnet', 'preprod', or 'preview'
 * @param options - Optional configuration
 * @param options.testMempool - If true, verifies the transaction appears in mempool before block inclusion. False by default.
 * @param options.blockchainParameters - Pre-fetched blockchain parameters (protocol params and current slot). If not provided, they will be fetched.
 * @param options.fetchParametersFromPublicAPI - If true, fetches blockchain parameters from public Blockfrost API instead of the configured backend. Defaults to false.
 * @param options.verifyTxUsingPublicAPI - If true, verifies transaction confirmation using public Blockfrost API instead of the configured backend. Defaults to false,
 */
export const submitTest = async (
  network: Network,
  options?: {
    testMempool?: boolean;
    blockchainParameters?: BlockchainParameters;
    fetchParametersFromPublicAPI?: boolean;
    verifyTxUsingPublicAPI?: boolean;
  },
)
...
```