### PR TITLE
fix(fixtures): accept both error types for broken pool metadata URL

### DIFF
--- a/src/fixtures/mainnet/pools/pool-id-metadata.ts
+++ b/src/fixtures/mainnet/pools/pool-id-metadata.ts
@@ -1,4 +1,5 @@
 import { expect } from 'vitest';
+import { oneOf } from '../../../matchers.js';
 
 export default [
   {
@@ -21,8 +22,7 @@ export default [
   },
   {
     id: 'pools-pool-id-metadata-pool-with-multiple-metadata-updates-in-one-update_edbde8d94192',
-    testName:
-      'pools/:pool_id/metadata - HTTP_RESPONSE_ERROR - only basic pool metadata info returned',
+    testName: 'pools/:pool_id/metadata - pool with broken metadata URL returns error',
     endpoints: [
       'pools/pool1yhd6a8vvp0r0ads36j4zjwx7juztf6cgpa2fqm9dm0st790ptf2/metadata',
       'pools/25dbae9d8c0bc6feb611d4aa2938de9704b4eb080f54906caddbe0bf/metadata',
@@ -36,11 +36,18 @@ export default [
       name: null,
       description: null,
       homepage: null,
-      error: {
-        code: 'HTTP_RESPONSE_ERROR',
-        message:
-          'Error Offchain Pool: HTTP Response error from https://git.io/JmBOm resulted in HTTP status code : 404 "Not Found"',
-      },
+      error: oneOf(
+        {
+          code: 'HTTP_RESPONSE_ERROR',
+          message:
+            'Error Offchain Pool: HTTP Response error from https://git.io/JmBOm resulted in HTTP status code : 404 "Not Found"',
+        },
+        {
+          code: 'CONNECTION_ERROR',
+          message:
+            'Error Offchain Pool: Connection failure error when fetching metadata from https://git.io/JmBOm.',
+        },
+      ),
     },
   },
   {

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -280,6 +280,32 @@ export function toBeCurrentBlockHeight(received: number, options?: { toleranceIn
   };
 }
 
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (typeof a !== typeof b || a === null || b === null || typeof a !== 'object') return false;
+  const aObj = a as Record<string, unknown>;
+  const bObj = b as Record<string, unknown>;
+  const keys = Object.keys(aObj);
+
+  return keys.length === Object.keys(bObj).length && keys.every(k => deepEqual(aObj[k], bObj[k]));
+}
+
+/**
+ * Asymmetric matcher that accepts any value deeply equal to one of the
+ * provided alternatives. Useful inside `toStrictEqual` when multiple
+ * valid responses are acceptable.
+ */
+export function oneOf<T>(...expected: T[]) {
+  return {
+    asymmetricMatch(received: unknown): boolean {
+      return expected.some(value => deepEqual(received, value));
+    },
+    toString() {
+      return `OneOf(${expected.map(v => JSON.stringify(v)).join(' | ')})`;
+    },
+  };
+}
+
 export const toBeAssetUnit = (received: string) => {
   return {
     pass: typeof received === 'string',


### PR DESCRIPTION
## Context

A Mainnet fixture sometimes fails with Dolos, e.g. https://github.com/blockfrost/blockfrost-platform/actions/runs/25881597135/job/76062762408

The `git.io/JmBOm` redirect chain is flaky, and Dolos sometimes times out before reaching the final `http/404`, returning `CONNECTION_ERROR` instead of `HTTP_RESPONSE_ERROR`.

Proposal: accept either via a new `oneOf()` asymmetric matcher.

@vladimirvolek, WDYT, would this be acceptable?