### PR TITLE
feat: extend /governance/dreps tests for new list fields and query params

### DIFF
--- a/src/fixtures/common/governance/dreps.ts
+++ b/src/fixtures/common/governance/dreps.ts
@@ -1,0 +1,106 @@
+import { expect } from 'vitest';
+import { Got } from 'got';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type DrepListItem = { amount: string; retired: boolean; expired: boolean } & Record<string, any>;
+
+const expectDrepArray = (response: unknown): DrepListItem[] => {
+  expect(Array.isArray(response)).toBe(true);
+
+  return response as DrepListItem[];
+};
+
+const isSorted = (amounts: bigint[], direction: 'asc' | 'desc') =>
+  amounts.every((amount, index) => {
+    if (index === 0) return true;
+    const previous = amounts[index - 1];
+
+    return direction === 'asc' ? previous <= amount : previous >= amount;
+  });
+
+// Fetches the first two pages and asserts the concatenation is sorted. Spanning
+// two pages ensures sorting is applied across the whole result set, not just
+// within a single page.
+const assertSortedAcrossPages = async (
+  endpoint: string,
+  client: Got,
+  direction: 'asc' | 'desc',
+) => {
+  const [page1, page2] = await Promise.all([
+    client.get(endpoint).json<DrepListItem[]>(),
+    client.get(`${endpoint}&page=2`).json<DrepListItem[]>(),
+  ]);
+
+  expect(page1.length).toBeGreaterThan(0);
+
+  const amounts = [...page1, ...page2].map(drep => BigInt(drep.amount));
+
+  expect(isSorted(amounts, direction)).toBe(true);
+};
+
+export default [
+  {
+    id: 'governance-dreps-order-by-amount-desc_5d8f1c0a2b34',
+    testName: 'governance/dreps order_by=amount (desc)',
+    endpoints: ['governance/dreps?count=100&order_by=amount&order=desc'],
+    customTest: async (endpoint: string, client: Got) =>
+      assertSortedAcrossPages(endpoint, client, 'desc'),
+  },
+  {
+    id: 'governance-dreps-order-by-amount-asc_9a1e7b4c6d20',
+    testName: 'governance/dreps order_by=amount (asc)',
+    endpoints: ['governance/dreps?count=100&order_by=amount&order=asc'],
+    customTest: async (endpoint: string, client: Got) =>
+      assertSortedAcrossPages(endpoint, client, 'asc'),
+  },
+  {
+    id: 'governance-dreps-retired-true_3f6c2d9e8a17',
+    testName: 'governance/dreps retired=true',
+    endpoints: ['governance/dreps?count=100&retired=true'],
+    customExpect: async (response: unknown) => {
+      const dreps = expectDrepArray(response);
+
+      expect(dreps.every(drep => drep.retired === true)).toBe(true);
+    },
+  },
+  {
+    id: 'governance-dreps-retired-false_71b0e4a5c2d9',
+    testName: 'governance/dreps retired=false',
+    endpoints: ['governance/dreps?count=100&retired=false'],
+    customExpect: async (response: unknown) => {
+      const dreps = expectDrepArray(response);
+
+      expect(dreps.every(drep => drep.retired === false)).toBe(true);
+    },
+  },
+  {
+    id: 'governance-dreps-expired-true_2c8d5f1a9b46',
+    testName: 'governance/dreps expired=true',
+    endpoints: ['governance/dreps?count=100&expired=true'],
+    customExpect: async (response: unknown) => {
+      const dreps = expectDrepArray(response);
+
+      expect(dreps.every(drep => drep.expired === true)).toBe(true);
+    },
+  },
+  {
+    id: 'governance-dreps-expired-false_8e3a1d7c4f02',
+    testName: 'governance/dreps expired=false',
+    endpoints: ['governance/dreps?count=100&expired=false'],
+    customExpect: async (response: unknown) => {
+      const dreps = expectDrepArray(response);
+
+      expect(dreps.every(drep => drep.expired === false)).toBe(true);
+    },
+  },
+  {
+    id: 'governance-dreps-retired-false-expired-false_4a9f0b2e6c81',
+    testName: 'governance/dreps retired=false&expired=false',
+    endpoints: ['governance/dreps?count=100&retired=false&expired=false'],
+    customExpect: async (response: unknown) => {
+      const dreps = expectDrepArray(response);
+
+      expect(dreps.every(drep => drep.retired === false && drep.expired === false)).toBe(true);
+    },
+  },
+];

--- a/src/fixtures/common/index.ts
+++ b/src/fixtures/common/index.ts
@@ -9,6 +9,7 @@ import utilsTxsEvaluate from './utils/txs-evaluate.js';
 import utilsTxsEvaluateUtxos from './utils/txs-evaluate-utxos.js';
 import assetUtxos from './assets/asset-utxos.js';
 import swapsAsset from './swaps/asset.js';
+import governanceDreps from './governance/dreps.js';
 
 export const commonFixtures = {
   health: [...healthRoot, ...healthClock],
@@ -18,4 +19,5 @@ export const commonFixtures = {
   blocks: [...blocksLatest, ...blocksLatestTxs, ...blocksLatestTxsCbor],
   epochs: [...epochsLatest],
   utils: [...utilsTxsEvaluate, ...utilsTxsEvaluateUtxos],
+  governance: [...governanceDreps],
 };

--- a/src/fixtures/mainnet/governance/dreps/index.ts
+++ b/src/fixtures/mainnet/governance/dreps/index.ts
@@ -1,4 +1,6 @@
+import { expect } from 'vitest';
 import { getPaginationFixtures } from '../../../../index.js';
+import { drepListMetadata } from '../../../../matchers.js';
 
 const paginationFixtures = getPaginationFixtures('governance/dreps');
 
@@ -7,401 +9,107 @@ export default [
   {
     id: 'governance-dreps-list_1cc0cb3cc8cc',
     testName: 'governance dreps list',
-    endpoints: ['governance/dreps'],
+    endpoints: ['governance/dreps?count=10'],
     response: [
       {
         drep_id: 'drep1yfaaaaa270yjt6tu5skndugekprf5ykv5jshanl0c6gqx5qpstskf',
         hex: '227bdef7aaf3c925e97ca42d36f119b0469a12cca4a17ecfefc6900350',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
       },
       {
         drep_id: 'drep1yg8lwytwjymrjry2xqe7u6xavft6pharse7hnl4pjdqz5tsaexul0',
         hex: '220ff7116e9136390c8a3033ee68dd6257a0dfa3867d79fea193402a2e',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
       },
       {
         drep_id: 'drep1yfkg5ryqwaleunwqg0dtcj8g8yw8sgd9kskg2zlzdr8355gpghcvv',
         hex: '226c8a0c80777f9e4dc043dabc48e8391c7821a5b42c850be268cf1a51',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
       },
       {
         drep_id: 'drep1y0j6kdexrv7kxcqd2ejkfpunwzh2qv02xyytpf4a3nh432shwau2w',
         hex: '23e5ab37261b3d63600d566564879370aea031ea3108b0a6bd8cef58aa',
+        amount: expect.toBeAdaQuantity(),
+        has_script: true,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
       },
       {
         drep_id: 'drep1yf2jzhuc4f7eu2yay9d9ta3dykxxcwn34wz8kak7nhd7vcgrxn7ns',
         hex: '2255215f98aa7d9e289d215a55f62d258c6c3a71ab847b76de9ddbe661',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
       },
       {
         drep_id: 'drep1ytwmwvtd0a8lr45ssner2tjxzv5y8q03w3606yeald9mdmgmwecja',
         hex: '22ddb7316d7f4ff1d69084f2352e4613284381f17474fd133dfb4bb6ed',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
       },
       {
         drep_id: 'drep1ygkmm9yfrf99w63ystylklwnsky7vxhseech0nak7hd7vwgzjzxhy',
         hex: '222dbd94891a4a576a2482c9fb7dd38589e61af0ce7177cfb6f5dbe639',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
       },
       {
         drep_id: 'drep1y2csyxt7u2hl4674pl9cef5lknafaw5nraxvyx033kmd0es3awuv0',
         hex: '22b102197ee2affaebd50fcb8ca69fb4fa9eba931f4cc219f18db6d7e6',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
       },
       {
         drep_id: 'drep1ytn29gxylzlrhzmkt4c75w7qmesxqc248r9089f0pvuysdqeva6ht',
         hex: '22e6a2a0c4f8be3b8b765d71ea3bc0de6060615538caf3952f0b384834',
-      },
-      { drep_id: 'drep_always_abstain', hex: '' },
-      {
-        drep_id: 'drep1y25c4qx64mfs7m2vlgpyq0mcpl8r2xxk2wc7uvzv46pgu7gk23g28',
-        hex: '22a98a80daaed30f6d4cfa02403f780fce3518d653b1ee304cae828e79',
-      },
-      {
-        drep_id: 'drep1y2kvjq7k603rsykhhtxd4ct2nqdvqxr0mrxhd9qdffztrwsn6zna2',
-        hex: '22acc903d6d3e23812d7baccdae16a981ac0186fd8cd76940d4a44b1ba',
-      },
-      {
-        drep_id: 'drep1ytqzml628shvwje0644x4fj5h0r4nzvqgl9j6f3xsp5tcpqgeregw',
-        hex: '22c02dff4a3c2ec74b2fd56a6aa654bbc759898047cb2d26268068bc04',
-      },
-      {
-        drep_id: 'drep1ygvg07c0ath78u25uf4qv8ksg54alm0cp6vmhnc7wv0642g20adsz',
-        hex: '221887fb0feaefe3f154e26a061ed0452bdfedf80e99bbcf1e731faaa9',
-      },
-      {
-        drep_id: 'drep1y22eh8rzfmnjw8m82hlcgxfm8tcmwqmdqy2mjupdduztq0s5s5dkk',
-        hex: '22959b9c624ee7271f6755ff84193b3af1b7036d0115b9702d6f04b03e',
-      },
-      {
-        drep_id: 'drep1ygj02llvuusnhphvhlxf7d2cxhs53twjnwwl5at3zwht4xc6xdgl4',
-        hex: '2224f57fece7213b86ecbfcc9f355835e148add29b9dfa757113aeba9b',
-      },
-      { drep_id: 'drep_always_no_confidence', hex: '' },
-      {
-        drep_id: 'drep1y20w8vxwd3venlvp0muxwzmdlr7a006dpz580czmaj422sqng6fkg',
-        hex: '229ee3b0ce6c5999fd817ef8670b6df8fdd7bf4d08a877e05becaaa540',
-      },
-      {
-        drep_id: 'drep1yf8p623g9s0yxnlnjzealgajyxl57k7n6saeavc7azg0crcahnul9',
-        hex: '224e1d2a282c1e434ff390b3dfa3b221bf4f5bd3d43b9eb31ee890fc0f',
-      },
-      {
-        drep_id: 'drep1y25xtvu3d0gaf6cxktr9pkfgnywmqsh4fum93s8m3hlp4aqj3uqdp',
-        hex: '22a865b3916bd1d4eb06b2c650d928991db042f54f3658c0fb8dfe1af4',
-      },
-      {
-        drep_id: 'drep1y233tk9k202g9l9950czsnv4zd5229zq78dwf7drpn069rsfygqks',
-        hex: '22a315d8b653d482fca5a3f0284d951368a51440f1dae4f9a30cdfa28e',
-      },
-      {
-        drep_id: 'drep1y2jd3c4hgg0tdua58z6c64k9rf58lz3jlcjlxcjfeaspl6q2e9zm6',
-        hex: '22a4d8e2b7421eb6f3b438b58d56c51a687f8a32fe25f36249cf601fe8',
-      },
-      {
-        drep_id: 'drep1yf2aeluf52p8xsfzhj926f8tuv9jur9sv7hquysv52zhdfgsrljcn',
-        hex: '2255dcff89a282734122bc8aad24ebe30b2e0cb067ae0e120ca28576a5',
-      },
-      {
-        drep_id: 'drep1yftc8zs7gjcj4a9nxzplz4wg6cwweya0kxp8adnw59vsyrqvrysud',
-        hex: '2257838a1e44b12af4b33083f155c8d61cec93afb1827eb66ea159020c',
-      },
-      {
-        drep_id: 'drep1yghesd363wu6lscav46nlrt7mt90vhzzkkdfh4n62l8guhs72dmd7',
-        hex: '222f98363a8bb9afc31d65753f8d7edacaf65c42b59a9bd67a57ce8e5e',
-      },
-      {
-        drep_id: 'drep1ygnh2uf4wkc8ldgfxwz7rzuga3m8jtqew9xh5g3n587mg6g3ge0sj',
-        hex: '222775713575b07fb5093385e18b88ec76792c19714d7a2233a1fdb469',
-      },
-      {
-        drep_id: 'drep1yfpazkd0aqex0kd3vrhk47sjy0jqgq3xu6h2zv9wevfequcxyynwv',
-        hex: '2243d159afe83267d9b160ef6afa1223e4040226e6aea130aecb139073',
-      },
-      {
-        drep_id: 'drep1yfhusw50g9ujptwg028zp38pmnnq80xa7l60g0vyhrsngsqns67xn',
-        hex: '226fc83a8f417920adc87a8e20c4e1dce603bcddf7f4f43d84b8e13440',
-      },
-      {
-        drep_id: 'drep1yfp7s40f0s90na5f4hnwj8lw828xy6f28e6kcpscyzggrkscyn474',
-        hex: '2243e855e97c0af9f689ade6e91fee3a8e62692a3e756c0618209081da',
-      },
-      {
-        drep_id: 'drep1yth940m0pp00t5005s8q0qs9nsgeu2scqjfurmczjxl3z8q8sgq3q',
-        hex: '22ee5abf6f085ef5d1efa40e0782059c119e2a180493c1ef0291bf111c',
-      },
-      {
-        drep_id: 'drep1yfffe5kmskfgr9dsd2vusp9r58vafustu6lf85579c590gskc9j6r',
-        hex: '22529cd2db85928195b06a99c804a3a1d9d4f20be6be93d29e2e2857a2',
-      },
-      {
-        drep_id: 'drep1y290s8rwsezxkct6urmqne8tc92wqtltal8dfxfk45xj6eqn2mgfx',
-        hex: '228af81c6e86446b617ae0f609e4ebc154e02febefced49936ad0d2d64',
-      },
-      {
-        drep_id: 'drep1y23gllhnq05qh74pzlnndyr3c8yyxhdfx92mu7a7mj3rjsgla9plx',
-        hex: '22a28ffef303e80bfaa117e7369071c1c8435da93155be7bbedca23941',
-      },
-      {
-        drep_id: 'drep1ytjyvm958ywjkp57f8wm3havj72lc653tp7ajttxxt6ftgcmcmdk2',
-        hex: '22e4466cb4391d2b069e49ddb8dfac9795fc6a91587dd92d6632f495a3',
-      },
-      {
-        drep_id: 'drep1y26xglh8ruqjurm4vuxxs3xa3p56jdfp2azpu983mcnfseqeg60y8',
-        hex: '22b4647ee71f012e0f75670c6844dd8869a9352157441e14f1de269864',
-      },
-      {
-        drep_id: 'drep1ytc573ug2gx24r6kxzag0paefdll7lr48rakj8mnkws60fs6lj7fq',
-        hex: '22f14f4788520caa8f5630ba8787b94b7fff7c7538fb691f73b3a1a7a6',
-      },
-      {
-        drep_id: 'drep1y28uwdrz2acyp4jka5fqp2fa3hp0klpme8wug3f5p2y45zsc0e8qw',
-        hex: '228fc73462577040d656ed1200a93d8dc2fb7c3bc9ddc445340a895a0a',
-      },
-      {
-        drep_id: 'drep1ygttcya6jdd7k2tvt3lmfk0y0pg2xknvlkd34h0n20y7d9qvm46l4',
-        hex: '2216bc13ba935beb296c5c7fb4d9e47850a35a6cfd9b1addf353c9e694',
-      },
-      {
-        drep_id: 'drep1yt57vz5uvuj08rp5jk0ndnw476qtsgf0r5dp64wy0jfat4qyvajvw',
-        hex: '22e9e60a9c6724f38c34959f36cdd5f680b8212f1d1a1d55c47c93d5d4',
-      },
-      {
-        drep_id: 'drep1yg04a5ulpxkwsu9wyf535mdt2vzsyxcvqupmsu42ucufensqkaw4r',
-        hex: '221f5ed39f09ace870ae22691a6dab5305021b0c0703b872aae6389cce',
-      },
-      {
-        drep_id: 'drep1ygwscks2yt0na4fqpcdyqn0fare5v48y0mjgn2g478lnx8gue393e',
-        hex: '221d0c5a0a22df3ed5200e1a404de9e8f34654e47ee489a915f1ff331d',
-      },
-      {
-        drep_id: 'drep1ygny6qfdmretrjufrzr6kr72jqtaddqa90c367usrlgyjls7yrjw8',
-        hex: '22264d012dd8f2b1cb891887ab0fca9017d6b41d2bf11d7b901fd0497e',
-      },
-      {
-        drep_id: 'drep1yge0mv24sxq550nhqj3vxmgmffup0hgjpv67fvc79wgwxdgskhpv5',
-        hex: '2232fdb15581814a3e7704a2c36d1b4a7817dd120b35e4b31e2b90e335',
-      },
-      {
-        drep_id: 'drep1y296z8tm7y7elwsmsewn4q2tdr5gu0fqztq97yttlpv7zycvsl554',
-        hex: '228ba11d7bf13d9fba1b865d3a814b68e88e3d2012c05f116bf859e113',
-      },
-      {
-        drep_id: 'drep1y2u3wureq2gy33ajq09geg7n24dg8243v95w6wee5hhq45cvahwhw',
-        hex: '22b9177079029048c7b203ca8ca3d3555a83aab16168ed3b39a5ee0ad3',
-      },
-      {
-        drep_id: 'drep1yfhjdcteppvkff24ev9ew67eesgnu4euk2hyc7u422qr4zc996rvm',
-        hex: '226f26e179085964a555cb0b976bd9cc113e573cb2ae4c7b9552803a8b',
-      },
-      {
-        drep_id: 'drep1yfy7wx6kvxwfp2pyn057kz4gtl8dd70qmudmv3gxv9ntazcdx803p',
-        hex: '2249e71b56619c90a8249be9eb0aa85fced6f9e0df1bb645066166be8b',
-      },
-      {
-        drep_id: 'drep1yfcdzuag647evc9tmr5rawpl4t3x4qxlagyy5taj6al7wwqr8qye5',
-        hex: '2270d173a8d57d9660abd8e83eb83faae26a80dfea084a2fb2d77fe738',
-      },
-      {
-        drep_id: 'drep1yffqtkqaxkmdv5wxjrtc0xgh7ymlylq9yt0t9w37tmx7hkq38lkrl',
-        hex: '225205d81d35b6d651c690d7879917f137f27c0522deb2ba3e5ecdebd8',
-      },
-      {
-        drep_id: 'drep1yfg6uekyj9mkvf9eyf6p04vufhmcw3tvefscqttdl6m7v3sdw0udf',
-        hex: '2251ae66c491776624b9227417d59c4df787456cca61802d6dfeb7e646',
-      },
-      {
-        drep_id: 'drep1ytkt0vvxqlwmws5n04ud2q3sk0yu9lh65arkp2suaqdgmgqgrza6c',
-        hex: '22ecb7b18607ddb742937d78d50230b3c9c2fefaa74760aa1ce81a8da0',
-      },
-      {
-        drep_id: 'drep1y2j502uqsjl7ujrg5e73mxc2up2wu963r6eg44zdglzanncytjpxy',
-        hex: '22a547ab8084bfee4868a67d1d9b0ae054ee17511eb28ad44d47c5d9cf',
-      },
-      {
-        drep_id: 'drep1yffgdq6yj7rm46tse8y7ctk3yg5zun4rc9hd8kwjj6u4z0qaqtdnn',
-        hex: '22528683449787bae970c9c9ec2ed122282e4ea3c16ed3d9d296b9513c',
-      },
-      {
-        drep_id: 'drep1yt6l40htemepw0rwe5gtptm2en6xfepyvpfryltap0epnlq3jh536',
-        hex: '22f5fabeebcef2173c6ecd10b0af6accf464e4246052327d7d0bf219fc',
-      },
-      {
-        drep_id: 'drep1ytj6kdexrv7kxcqd2ejkfpunwzh2qv02xyytpf4a3nh432shudd2f',
-        hex: '22e5ab37261b3d63600d566564879370aea031ea3108b0a6bd8cef58aa',
-      },
-      {
-        drep_id: 'drep1ygtfufqpjlj4vn6nawc6vw6d89wu67xv43cz3z4umpsuj4sv76j9g',
-        hex: '22169e240197e5564f53ebb1a63b4d395dcd78ccac70288abcd861c956',
-      },
-      {
-        drep_id: 'drep1ytkzpmmukjy6qn6xd5skqm0ypcj5juw9rxddr5mmlzgjvtcghwqjr',
-        hex: '22ec20ef7cb489a04f466d21606de40e254971c5199ad1d37bf891262f',
-      },
-      {
-        drep_id: 'drep1y2cnrwkyg6wtsw9jm3tx7hj39nmnhwnmffup6v2sunjqvus4tlua9',
-        hex: '22b131bac4469cb838b2dc566f5e512cf73bba7b4a781d3150e4e40672',
-      },
-      {
-        drep_id: 'drep1y27rrajt9p52law0s5nx6nkzt9k6fvfrm28vlr7h2cdy8as89gxwr',
-        hex: '22bc31f64b2868aff5cf85266d4ec2596da4b123da8ecf8fd7561a43f6',
-      },
-      {
-        drep_id: 'drep1ygwkyyf3a6gucvlk37rhcutlrtaheupgcd5rvfqc97v6tmsnaesgd',
-        hex: '221d621131ee91cc33f68f877c717f1afb7cf028c3683624182f99a5ee',
-      },
-      {
-        drep_id: 'drep1yts3qdjsqcnhld4r3uek2uu0n2tnh824tgnf75a83q3yhequuy54u',
-        hex: '22e110365006277fb6a38f3365738f9a973b9d555a269f53a788224be4',
-      },
-      {
-        drep_id: 'drep1yg3gl27d62c6qdz4ffay9kkutywk2sxw2shvp4a8xjse0vg850rla',
-        hex: '22228fabcdd2b1a034554a7a42dadc591d6540ce542ec0d7a734a197b1',
-      },
-      {
-        drep_id: 'drep1yfa8r8r36x7x05htftce7qhafrn5nzzr6vazy95pzy6y5dqac0ss7',
-        hex: '227a719c71d1bc67d2eb4af19f02fd48e7498843d33a22168111344a34',
-      },
-      {
-        drep_id: 'drep1yt35g6t3apv7k4526kqle54jmchuru439kyzuvqhwq584gcr3a658',
-        hex: '22e3446971e859eb568ad581fcd2b2de2fc1f2b12d882e301770287aa3',
-      },
-      {
-        drep_id: 'drep1ytw5tvdxpe39l9gm3g49gl0whwd2dgu4mcf5ml5z3zfuk3s8npegv',
-        hex: '22dd45b1a60e625f951b8a2a547deebb9aa6a395de134dfe828893cb46',
-      },
-      {
-        drep_id: 'drep1y296zyw2r8rcsy7slkd7l687hh88xc0m6ac2y3h2r3mvsdgc9q6yy',
-        hex: '228ba111ca19c78813d0fd9befe8febdce7361fbd770a246ea1c76c835',
-      },
-      {
-        drep_id: 'drep1y2m0g4r66pyaw3p7u454wc0p4f0ygm8ueaev0mgd3tvwm7sskqwqp',
-        hex: '22b6f4547ad049d7443ee5695761e1aa5e446cfccf72c7ed0d8ad8edfa',
-      },
-      {
-        drep_id: 'drep1yfz5v7qq7jjhdt83mk6lfcrfrmf5g84v0nlarrdc9f0qxasv6wlf5',
-        hex: '2245467800f4a576acf1ddb5f4e0691ed3441eac7cffd18db82a5e0376',
-      },
-      {
-        drep_id: 'drep1ytfnmf4uftt4fe0h63xhadl0v402gr6nnhtcgrq2sas26kgaf3n5y',
-        hex: '22d33da6bc4ad754e5f7d44d7eb7ef655ea40f539dd7840c0a8760ad59',
-      },
-      {
-        drep_id: 'drep1yfk9pcvlh2j8m4azy6s463338v4s3qz9k8lzz605q9wh6zqjrckq2',
-        hex: '226c50e19fbaa47dd7a226a15d46313b2b088045b1fe2169f4015d7d08',
-      },
-      {
-        drep_id: 'drep1yg6ksg7d0nvpn40hclmyyzvvk062vf242uwyk0utladvlqq5npffx',
-        hex: '22356823cd7cd819d5f7c7f642098cb3f4a62555571c4b3f8bff5acf80',
-      },
-      {
-        drep_id: 'drep1yfj3fur4ru2frk7xjt3g0ycqsy73ypd5h2n3xe36h9v2hdcftv9qn',
-        hex: '226514f0751f1491dbc692e2879300813d1205b4baa713663ab958abb7',
-      },
-      {
-        drep_id: 'drep1ythhhe3s0utzdsvjgcshqzxhfx6q3qy896ynlv555nmj45skec2ez',
-        hex: '22ef7be6307f1626c19246217008d749b40880872e893fb294a4f72ad2',
-      },
-      {
-        drep_id: 'drep1ytwk5agfmq6gcl445d0wk5u5dzyutz2h4f8nuktxvmltjycayek05',
-        hex: '22dd6a7509d8348c7eb5a35eeb53946889c58957aa4f3e596666feb913',
-      },
-      {
-        drep_id: 'drep1yg8vjs7ute7z7vyd8yez5tgjey6043djjfh8d3n7sjev35g064xxc',
-        hex: '220ec943dc5e7c2f308d39322a2d12c934fac5b2926e76c67e84b2c8d1',
-      },
-      {
-        drep_id: 'drep1yfazn9u95ws2tmdgm3jtlhnngermcnrps5stje4aq96776g3vwgn9',
-        hex: '227a299785a3a0a5eda8dc64bfde734647bc4c618520b966bd0175ef69',
-      },
-      {
-        drep_id: 'drep1y2anuetphncrua2ya46uwgw0rwkyzxr7jll0rv9259u0zvgrh3ng2',
-        hex: '22bb3e6561bcf03e7544ed75c721cf1bac41187e97fef1b0aaa178f131',
-      },
-      {
-        drep_id: 'drep1yfmmjfd8luqzuumc6tce0dhn39y752kgcye99amdxz7h25ga4ykrs',
-        hex: '2277b925a7ff002e7378d2f197b6f38949ea2ac8c13252f76d30bd7551',
-      },
-      {
-        drep_id: 'drep1yt49c9gfsrhf3uzl0ayw0rwykhqssmc6akyhwa7lyvuhltgehnnhv',
-        hex: '22ea5c150980ee98f05f7f48e78dc4b5c1086f1aed897777df23397fad',
-      },
-      {
-        drep_id: 'drep1y2lddxrx33g6ws8xk3nhcuzzew0qualmkc763s3hvgn6wks7c94ax',
-        hex: '22bed698668c51a740e6b4677c7042cb9e0e77fbb63da8c2376227a75a',
-      },
-      {
-        drep_id: 'drep1yfrmyrf4twcxa0z3w63842ktmufdu06c3vdaz8rpkgzu8gclnyuh9',
-        hex: '2247b20d355bb06ebc5176a27aaacbdf12de3f588b1bd11c61b205c3a3',
-      },
-      {
-        drep_id: 'drep1y2puqlfzl57a5z44qjnjpnxn938mrmcjxqvpsmxq8dxntrczq2yhn',
-        hex: '2283c07d22fd3dda0ab504a720ccd32c4fb1ef123018186cc03b4d358f',
-      },
-      {
-        drep_id: 'drep1y2zu74gt8sxtrxcngqsmrnupkzrtmlqshmvmm5qtuhxx6xqt7yhaw',
-        hex: '2285cf550b3c0cb19b134021b1cf81b086bdfc10bed9bdd00be5cc6d18',
-      },
-      {
-        drep_id: 'drep1y20sf6ql6azcz5f44ssejqgwf7lhgqqchhl2mags8tmkfwg8e6t84',
-        hex: '229f04e81fd745815135ac2199010e4fbf740018bdfeadf5103af764b9',
-      },
-      {
-        drep_id: 'drep1y2k4exm56hlzv5dey8tgghlflks0ks70a9e4nu7q8xd45wsvpfmn4',
-        hex: '22ad5c9b74d5fe2651b921d6845fe9fda0fb43cfe97359f3c0399b5a3a',
-      },
-      {
-        drep_id: 'drep1yfkcs4npza5kvnrruwnjahs6ptj9g2zhuju6vu2xvsnx0mqvry3vp',
-        hex: '226d8856611769664c63e3a72ede1a0ae4542857e4b9a67146642667ec',
-      },
-      {
-        drep_id: 'drep1yftygd96upvdnhfpjrmljj6rg2jja8lk4rt6sggxqa96xfc42fad8',
-        hex: '22564434bae058d9dd2190f7f94b4342a52e9ff6a8d7a82106074ba327',
-      },
-      {
-        drep_id: 'drep1yfm4z5u70l70r4yl98mlhfc03q2xz8y7y55ef5zh2qdmqpgsa57d3',
-        hex: '227751539e7ffcf1d49f29f7fba70f8814611c9e252994d057501bb005',
-      },
-      {
-        drep_id: 'drep1y20fpc0f6qjl4edtl9cxzrvqzd8jkzr6ja7p0p2n7cxragqkurae3',
-        hex: '229e90e1e9d025fae5abf970610d80134f2b087a977c178553f60c3ea0',
-      },
-      {
-        drep_id: 'drep1y23wk4w6f2aumc92vl9m3x74xzm6jh4ha9wdq09yfq2sl6q8zlv4l',
-        hex: '22a2eb55da4abbcde0aa67cbb89bd530b7a95eb7e95cd03ca448150fe8',
-      },
-      {
-        drep_id: 'drep1ytwrrcldyr7wlgywsz3zn0vyxxry7kv4nxzm07t49ee4udsmz3s9l',
-        hex: '22dc31e3ed20fcefa08e80a229bd8431864f59959985b7f9752e735e36',
-      },
-      {
-        drep_id: 'drep1ygtvnwgsucstvesms2hv9vc8hw3tye5zhzldmszrxqd2rxsje5c6m',
-        hex: '2216c9b910e620b6661b82aec2b307bba2b26682b8beddc043301aa19a',
-      },
-      {
-        drep_id: 'drep1yg69ym562ef340hyayryfmppjlalrzwxq9j6dfan0kxadmgnr7n9w',
-        hex: '2234526e9a56531abee4e90644ec2197fbf189c60165a6a7b37d8dd6ed',
-      },
-      {
-        drep_id: 'drep1ytd7d7m7kcsmd9hvj0fqsx236hhryv2zccugxw2dgua9e8qasp8jm',
-        hex: '22dbe6fb7eb621b696ec93d2081951d5ee323142c63883394d473a5c9c',
-      },
-      {
-        drep_id: 'drep1yf9z2h2v433ysezypurlrw8hfd9a3jfs4mj7esd0rwxnpasvvwwjr',
-        hex: '224a255d4cac624864440f07f1b8f74b4bd8c930aee5ecc1af1b8d30f6',
-      },
-      {
-        drep_id: 'drep1yfh3y46ffal6gyuf42e26urg5yyjecrgu2qyaj6zr8amk2sx3yn8g',
-        hex: '226f1257494f7fa41389aab2ad7068a1092ce068e2804ecb4219fbbb2a',
-      },
-      {
-        drep_id: 'drep1yteze88u2ck9wup8kr87qxf2tj736epvqr8cekaxxh5y5estsal7h',
-        hex: '22f22c9cfc562c577027b0cfe0192a5cbd1d642c00cf8cdba635e84a66',
-      },
-      {
-        drep_id: 'drep1ytvslw2a9ww8jvd72zrgm59q9e865x9nf6nd8j4lpdgw93g42k3cr',
-        hex: '22d90fb95d2b9c7931be50868dd0a02e4faa18b34ea6d3cabf0b50e2c5',
-      },
-      {
-        drep_id: 'drep1yftt6vj6k5l4h0mhp7q5362uxmhepee0l9q6nly8fplttcgkzushd',
-        hex: '2256bd325ab53f5bbf770f8148e95c36ef90e72ff941a9fc87487eb5e1',
-      },
-      {
-        drep_id: 'drep1yt2hzzh7t4u7xmunqapsvztx5468l30cfgzyvkw8zxwh2nga9vryr',
-        hex: '22d5710afe5d79e36f930743060966a5747fc5f84a044659c7119d754d',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
+      },
+      {
+        drep_id: 'drep_always_abstain',
+        hex: '',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
       },
     ],
   },

--- a/src/fixtures/preprod/governance/dreps/index.ts
+++ b/src/fixtures/preprod/governance/dreps/index.ts
@@ -1,4 +1,6 @@
+import { expect } from 'vitest';
 import { getPaginationFixtures } from '../../../../index.js';
+import { drepListMetadata } from '../../../../matchers.js';
 
 const paginationFixtures = getPaginationFixtures('governance/dreps');
 
@@ -7,173 +9,107 @@ export default [
   {
     id: 'governance-dreps-list_e28c1d992335',
     testName: 'governance dreps list',
-    endpoints: ['governance/dreps?count=43'],
+    endpoints: ['governance/dreps?count=10'],
     response: [
       {
         drep_id: 'drep1ytcw6qzpqqclx2yd0zy64ztvlkkhnf6yrzza8whgnq4vz5gh89626',
         hex: '22f0ed00410031f3288d7889aa896cfdad79a7441885d3bae8982ac151',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
       },
-      { drep_id: 'drep_always_abstain', hex: '' },
+      {
+        drep_id: 'drep_always_abstain',
+        hex: '',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
+      },
       {
         drep_id: 'drep1ytax4rwzvdwamnu67j2uk9z00660lpzcvmlys6266l9kt5c262k7m',
         hex: '22fa6a8dc2635dddcf9af495cb144f7eb4ff845866fe48695ad7cb65d3',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
       },
       {
         drep_id: 'drep1yg3mcc7w6njqkgkafes9rsjchgud2euas83n7d87tewdkngpgk07n',
         hex: '2223bc63ced4e40b22dd4e6051c258ba38d5679d81e33f34fe5e5cdb4d',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
       },
       {
         drep_id: 'drep1ygr9e6ld7a2k5h5ke36rfr3m8552qysq7exrllyhuexjsjgupmusz',
         hex: '22065cebedf7556a5e96cc74348e3b3d28a01200f64c3ffc97e64d2849',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
       },
       {
         drep_id: 'drep1yf6rudz7w9kz4etshj0njg7fjtd0c4frgsds6f8e6ep47ygl6sw74',
         hex: '22743e345e716c2ae570bc9f3923c992dafc5523441b0d24f9d6435f11',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
       },
-      { drep_id: 'drep_always_no_confidence', hex: '' },
+      {
+        drep_id: 'drep_always_no_confidence',
+        hex: '',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
+      },
       {
         drep_id: 'drep1yfm66g77aau5r06j0xm4nc4ljf8v2hnkdp6hcs8mwzxnulslc2ecs',
         hex: '2277ad23deef7941bf5279b759e2bf924ec55e7668757c40fb708d3e7e',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
       },
       {
         drep_id: 'drep1y2j502uqsjl7ujrg5e73mxc2up2wu963r6eg44zdglzanncytjpxy',
         hex: '22a547ab8084bfee4868a67d1d9b0ae054ee17511eb28ad44d47c5d9cf',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
       },
       {
         drep_id: 'drep1yfy9wajz7mrc6x5a4s23x5vttztqea6ajx9v83xcr6c5xlqxjx05p',
         hex: '2248577642f6c78d1a9dac1513518b58960cf75d918ac3c4d81eb1437c',
-      },
-      {
-        drep_id: 'drep1yvj9cn7cwc3wyrt3lclk2ua92lxd8uxqzju0qza8ky380uqjpzm8s',
-        hex: '23245c4fd87622e20d71fe3f6573a557ccd3f0c014b8f00ba7b12277f0',
-      },
-      {
-        drep_id: 'drep1ygytfjy863rx34wqlhjs3kpk8sxzehl2dullf7h0kpdajdgrga7lc',
-        hex: '2208b4c887d44668d5c0fde508d8363c0c2cdfea6f3ff4faefb05bd935',
-      },
-      {
-        drep_id: 'drep1yftr2094dxeszxy944y9n5ms5eg3md28adlvk0vqwcn4pgc7kq6wr',
-        hex: '2256353cb569b3011885ad4859d370a6511db547eb7ecb3d80762750a3',
-      },
-      {
-        drep_id: 'drep1ytk3r5ddfk2cq66ygdtkwf9yck6hhy7uzhk2tgl5d53448skyutw7',
-        hex: '22ed11d1ad4d95806b4443576724a4c5b57b93dc15eca5a3f46d235a9e',
-      },
-      {
-        drep_id: 'drep1ygq9x8fzmdzfdkr7g25urtf2ku6r0dhmn53vrxeq6v2upfgp9k56h',
-        hex: '2200531d22db4496d87e42a9c1ad2ab73437b6fb9d22c19b20d315c0a5',
-      },
-      {
-        drep_id: 'drep1ytsy6uatehlmxymymrwuycph0s6ewwn0jxsnyfq6vs47h4sflw0dg',
-        hex: '22e04d73abcdffb31364d8ddc260377c35973a6f91a132241a642bebd6',
-      },
-      {
-        drep_id: 'drep1yt5498apq2xmuvugmf0jdd5kp5zd3ccpezn6m2mzsvuh3pqn8x06l',
-        hex: '22e9529fa1028dbe3388da5f26b6960d04d8e301c8a7adab6283397884',
-      },
-      {
-        drep_id: 'drep1yfeewq0yz8f59e4rshwtas0h3mwrzs626xk3vmfqj4y394cz4mfl3',
-        hex: '22739701e411d342e6a385dcbec1f78edc31434ad1ad166d20954912d7',
-      },
-      {
-        drep_id: 'drep1yt4tspehdvggcd4e5cwsqlwulvyyrjj9jquuqu5wlyju9ns5wfc0z',
-        hex: '22eab807376b108c36b9a61d007ddcfb0841ca459039c0728ef925c2ce',
-      },
-      {
-        drep_id: 'drep1ywkfqpqap0ml82zptlqjdttajs6dhjxgwt6pamrvgsxacec6cntfp',
-        hex: '23ac90041d0bf7f3a8415fc126ad7d9434dbc8c872f41eec6c440ddc67',
-      },
-      {
-        drep_id: 'drep1yd86cta0va80fjmrsywmdw5wssn5lxjp8a6k0k94kw2f44g7qe2nw',
-        hex: '234fac2faf674ef4cb63811db6ba8e84274f9a413f7567d8b5b3949ad5',
-      },
-      {
-        drep_id: 'drep1ydcrhpsgdcvvedzc47dpppnyc4jgczzvshwyesfgvj3dcqqnxerlh',
-        hex: '23703b86086e18ccb458af9a108664c5648c084c85dc4cc12864a2dc00',
-      },
-      {
-        drep_id: 'drep1yvv7culkq0nqlgs6gtmkryuwp3lq49k5rhu6c7y2n2psu8g08rvmk',
-        hex: '2319ec73f603e60fa21a42f761938e0c7e0a96d41df9ac788a9a830e1d',
-      },
-      {
-        drep_id: 'drep1yvmeer7fcwng5ea3v7cw2g2uq352sm58xtmaphp5vqvcxycrzszhz',
-        hex: '23379c8fc9c3a68a67b167b0e5215c0468a86e8732f7d0dc3460198313',
-      },
-      {
-        drep_id: 'drep1ydmraa6kv8cvmry059v608tehl50nfmg0z764lmsqkvwurs40sw2z',
-        hex: '23763ef75661f0cd8c8fa159a79d79bfe8f9a76878bdaaff700598ee0e',
-      },
-      {
-        drep_id: 'drep1y2fgxycu78q496nj2mzkf2qqedfhv8evw46jd6nus659z0g3n4n6r',
-        hex: '229283131cf1c152ea7256c564a800cb53761f2c757526ea7c86a8513d',
-      },
-      {
-        drep_id: 'drep1yvd6c658yd6p9whut9sh3kthylyue2rhkgahmlfdrpu6degmr3t8z',
-        hex: '231bac6a87237412bafc596178d97727c9cca877b23b7dfd2d1879a6e5',
-      },
-      {
-        drep_id: 'drep1y09hnm54lxqfhjp7arnzef68ucwsd7t3nq4yvvej94t8f8qg0tqdt',
-        hex: '23cb79ee95f9809bc83ee8e62ca747e61d06f971982a4633322d56749c',
-      },
-      {
-        drep_id: 'drep1y22dlcgywnnj54z8ycd9ztdgcgn0xgex5gpufg5qzvmmklc70jqtz',
-        hex: '2294dfe10474e72a5447261a512da8c226f32326a203c4a2801337bb7f',
-      },
-      {
-        drep_id: 'drep1yfgxfdn3vdx3fjud2sl8rhvwksm6glhmg7cty2yzsekyyrgg5q0qj',
-        hex: '225064b671634d14cb8d543e71dd8eb437a47efb47b0b22882866c420d',
-      },
-      {
-        drep_id: 'drep1y2xuj82kwvjrnrgzsesh2yezg30neehkzwd9ed9kd20f2asze2l6z',
-        hex: '228dc91d567324398d028661751322445f3ce6f6139a5cb4b66a9e9576',
-      },
-      {
-        drep_id: 'drep1y29h2q6cst2pvkl2sqqvf5ljcy36uv7pmy482xnczddzgqshus24w',
-        hex: '228b75035882d4165bea8000c4d3f2c123ae33c1d92a751a78135a2402',
-      },
-      {
-        drep_id: 'drep1ywv7yxr3hyxksh9jd3qhz9562nj76nex7wwlc9smxhaczyscndlj8',
-        hex: '2399e21871b90d685cb26c4171169a54e5ed4f26f39dfc161b35fb8112',
-      },
-      {
-        drep_id: 'drep1ywldpc30gfsuk2ja07dmpdwcknudumcvl6qcgv4hnv60z9sl4umuv',
-        hex: '23bed0e22f4261cb2a5d7f9bb0b5d8b4f8de6f0cfe818432b79b34f116',
-      },
-      {
-        drep_id: 'drep1yfs2e9c42nq5fv2ac9ygxrhxllgaz9ms2g0xynaj7dpd58qwg2030',
-        hex: '2260ac971554c144b15dc148830ee6ffd1d11770521e624fb2f342da1c',
-      },
-      {
-        drep_id: 'drep1yge5qzj9ggvk77rz0vcmq2rpzcgq563e6fmydjngelxtnmgz2g54e',
-        hex: '2233400a4542196f78627b31b0286116100a6a39d27646ca68cfccb9ed',
-      },
-      {
-        drep_id: 'drep1ytg3f3uc0xda26q0q5fkg47dhlmdspm4hl3md8k6gcjk7zccfvsqc',
-        hex: '22d114c798799bd5680f05136457cdbff6d80775bfe3b69eda46256f0b',
-      },
-      {
-        drep_id: 'drep1y0gy6wwyuj6za8kamwm5rwmxxe5rk6pz4ckx3hmsfdjuujsr70shz',
-        hex: '23d04d39c4e4b42e9edddbb741bb6636683b6822ae2c68df704b65ce4a',
-      },
-      {
-        drep_id: 'drep1y28wyfxwyywajenkfcy0s9r3fqkvufm4stpxy80j4234qzsl80wwe',
-        hex: '228ee224ce211dd966764e08f81471482cce277582c2621df2aaa3500a',
-      },
-      {
-        drep_id: 'drep1y25j98kvqf7t3tj4pvxwrjr2728dsrfekptgg3kxqrr56qqcny8sn',
-        hex: '22a9229ecc027cb8ae550b0ce1c86af28ed80d39b0568446c600c74d00',
-      },
-      {
-        drep_id: 'drep1y2x6295xc930j929duvnjmac9yzra4ewk9kpgnzthmavvmcna8tpd',
-        hex: '228da51686c162f915456f19396fb829043ed72eb16c144c4bbefac66f',
-      },
-      {
-        drep_id: 'drep1y2aas36r3epqrz0gehkkkjm9yerwngm53lfsp83szymdtdq2whufp',
-        hex: '22bbd847438e420189e8cded6b4b652646e9a3748fd3009e301136d5b4',
-      },
-      {
-        drep_id: 'drep1yfmraa6kv8cvmry059v608tehl50nfmg0z764lmsqkvwurs4aql29',
-        hex: '22763ef75661f0cd8c8fa159a79d79bfe8f9a76878bdaaff700598ee0e',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
       },
     ],
   },

--- a/src/fixtures/preview/governance/dreps/index.ts
+++ b/src/fixtures/preview/governance/dreps/index.ts
@@ -1,4 +1,6 @@
+import { expect } from 'vitest';
 import { getPaginationFixtures } from '../../../../index.js';
+import { drepListMetadata } from '../../../../matchers.js';
 
 const paginationFixtures = getPaginationFixtures('governance/dreps');
 
@@ -7,401 +9,107 @@ export default [
   {
     id: 'governance-dreps-list_1cc0cb3cc8cc',
     testName: 'governance dreps list',
-    endpoints: ['governance/dreps'],
+    endpoints: ['governance/dreps?count=10'],
     response: [
       {
         drep_id: 'drep1y2ldnl4ugmhx873hpw7x23rvqe7krtwvgmvqjn3hy62xv6c8ashc0',
         hex: '22bed9febc46ee63fa370bbc65446c067d61adcc46d8094e372694666b',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
       },
       {
         drep_id: 'drep1yf52tuf5svq2mfkua3nljssmmtrzhf3pqpjq3m8gerj4r4s4f8cjn',
         hex: '2268a5f1348300ada6dcec67f9421bdac62ba621006408ece8c8e551d6',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
       },
       {
         drep_id: 'drep1y285lm709qqh54a5z5t6vl2kaaxqmszpsxs36dgh3h2n7nqltj46y',
         hex: '228f4fefcf28017a57b41517a67d56ef4c0dc04181a11d35178dd53f4c',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
       },
       {
         drep_id: 'drep1yghw6f8vp7wtzrda86yg79xva8taac45lkprj7ynu35te0slwd0q5',
         hex: '222eed24ec0f9cb10dbd3e888f14cce9d7dee2b4fd82397893e468bcbe',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
       },
       {
         drep_id: 'drep1yg8yhhtf3dxv9uh9rz6tr7j3jrgtc4n2cshe8snfsmk257gl87pyg',
         hex: '220e4bdd698b4cc2f2e518b4b1fa5190d0bc566ac42f93c26986ecaa79',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
       },
       {
         drep_id: 'drep1yfeewq0yz8f59e4rshwtas0h3mwrzs626xk3vmfqj4y394cz4mfl3',
         hex: '22739701e411d342e6a385dcbec1f78edc31434ad1ad166d20954912d7',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
       },
-      { drep_id: 'drep_always_abstain', hex: '' },
-      { drep_id: 'drep_always_no_confidence', hex: '' },
+      {
+        drep_id: 'drep_always_abstain',
+        hex: '',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
+      },
+      {
+        drep_id: 'drep_always_no_confidence',
+        hex: '',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
+      },
       {
         drep_id: 'drep1yvvxuvh64q9zdqgrjt76d42eclk5wgdxtnsun4808cwg0dquhj65s',
         hex: '23186e32faa80a26810392fda6d559c7ed4721a65ce1c9d4ef3e1c87b4',
+        amount: expect.toBeAdaQuantity(),
+        has_script: true,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
       },
       {
         drep_id: 'drep1yfvl3je6fh9zewfpystuzlxfdgmv94dpatvv6hkfruwt4gst9ny0g',
         hex: '2259f8cb3a4dca2cb9212417c17cc96a36c2d5a1ead8cd5ec91f1cbaa2',
-      },
-      {
-        drep_id: 'drep1ytp0gksk5e59v9h9vmqqlsyplevl30t6keu7u90fecsrg3sc63386',
-        hex: '22c2f45a16a6685616e566c00fc081fe59f8bd7ab679ee15e9ce203446',
-      },
-      {
-        drep_id: 'drep1yt2emvl35tdwnar7sxlaalepnar4u7l7uen0vjjq4ts8j8srcq5wn',
-        hex: '22d59db3f1a2dae9f47e81bfdeff219f475e7bfee666f64a40aae0791e',
-      },
-      {
-        drep_id: 'drep1ytg6la0qnt7lag3vypvwv34j5z2lreutsw4te5w72l7wudsjrp8lg',
-        hex: '22d1aff5e09afdfea22c2058e646b2a095f1e78b83aabcd1de57fcee36',
-      },
-      {
-        drep_id: 'drep1yfus3eg3tr384fx6ltew20n9j9ph7aduk743y6a77lgcy0cjl30y9',
-        hex: '227908e51158e27aa4dafaf2e53e6591437f75bcb7ab126bbef7d1823f',
-      },
-      {
-        drep_id: 'drep1yfzcnn53dd4t4xd225cnvj4zvg7huz578s6llln8qzasapsx5pvjs',
-        hex: '224589ce916b6aba99aa5531364aa2623d7e0a9e3c35fffe6700bb0e86',
-      },
-      {
-        drep_id: 'drep1y2e96usyjhhhda96ndcsykzy6z9jf4grf9jvt3v7f84sstqkyn2ne',
-        hex: '22b25d720495ef76f4ba9b71025844d08b24d5034964c5c59e49eb082c',
-      },
-      {
-        drep_id: 'drep1yt8rkalvjyyxzht3qc0cd3r0ua57wa2m0krt8dg2vfmnmqgj46mhe',
-        hex: '22ce3b77ec9108615d71061f86c46fe769e7755b7d86b3b50a62773d81',
-      },
-      {
-        drep_id: 'drep1yfy5e3nahwfydlsq84zz3ve5erd98yd836m74vj9qltwdnqgt95tk',
-        hex: '22494cc67dbb9246fe003d4428b334c8da5391a78eb7eab24507d6e6cc',
-      },
-      {
-        drep_id: 'drep1yfz3nu55mq9slnrxj7773umx9xlga0u4y7lqy0l8xeelr2gmgtk4c',
-        hex: '224519f294d80b0fcc6697bde8f36629be8ebf9527be023fe73673f1a9',
-      },
-      {
-        drep_id: 'drep1y2qkg2ahz82nxy7aa8danywky9q5cmftmur2jxqextep2ssdm6tvl',
-        hex: '2281642bb711d53313dde9dbd991d621414c6d2bdf06a9181932f21542',
-      },
-      {
-        drep_id: 'drep1yfw5agf8rpwa85k35mrxj606du69ujdkxpwsguvzxuyem6qt86k5z',
-        hex: '225d4ea127185dd3d2d1a6c66969fa6f345e49b6305d04718237099de8',
-      },
-      {
-        drep_id: 'drep1y2q252gsm6r3998yw6p32gr4v35jmhcm59wxmcwpkk3yc6qlr2ve9',
-        hex: '2280aa2910de871294e4768315207564692ddf1ba15c6de1c1b5a24c68',
-      },
-      {
-        drep_id: 'drep1ytze3qa9a5vg3zpgmhgrde0w0yzywh7tezxq92lpe9zt6rglfw774',
-        hex: '22c59883a5ed18888828ddd036e5ee7904475fcbc88c02abe1c944bd0d',
-      },
-      {
-        drep_id: 'drep1yfj2tt6ynx7wpunwguaamfewq6q9agdjcuerd3lhed5j6ggjeu7v8',
-        hex: '2264a5af4499bce0f26e473bdda72e06805ea1b2c73236c7f7cb692d21',
-      },
-      {
-        drep_id: 'drep1ytvk7yslg948lk54xehn4ct9jh2ef8s4vgglhhuph9ymefg9grd6j',
-        hex: '22d96f121f416a7fda95366f3ae16595d5949e156211fbdf81b949bca5',
-      },
-      {
-        drep_id: 'drep1yt5dr68azzrthyd9vhqt5xlfazu4vdd38hzd2lxumcqmlusn2wx7a',
-        hex: '22e8d1e8fd1086bb91a565c0ba1be9e8b95635b13dc4d57cdcde01bff2',
-      },
-      {
-        drep_id: 'drep1y2e0v2wu7uv6az9rp0udsf67sjw4qnvqu20nr4erhu8j6jgrgfr6j',
-        hex: '22b2f629dcf719ae88a30bf8d8275e849d504d80e29f31d723bf0f2d49',
-      },
-      {
-        drep_id: 'drep1ygh6kjwm5c2z5p6577a22hxet9knegakg8esp309w68enmsqmqls6',
-        hex: '222fab49dba6142a0754f7baa55cd9596d3ca3b641f300c5e5768f99ee',
-      },
-      {
-        drep_id: 'drep1yt76he02dprm2af6x26vg76mhs2vajlg43cr9jh9dq3f2qs68ts3s',
-        hex: '22fdabe5ea6847b5753a32b4c47b5bbc14cecbe8ac7032cae568229502',
-      },
-      {
-        drep_id: 'drep1y22k4k0rhmh7lm9dgsd8fv8f2g7zpxax294mdrk9m9u4h2q66zvlj',
-        hex: '22956ad9e3beefefecad441a74b0e9523c209ba6516bb68ec5d9795ba8',
-      },
-      {
-        drep_id: 'drep1ytkdk7j6g4jpnuamve0uy9kv2fyvlprdauv0ymtdpvkrt2gla0chu',
-        hex: '22ecdb7a5a456419f3bb665fc216cc5248cf846def18f26d6d0b2c35a9',
-      },
-      {
-        drep_id: 'drep1yt0aljj4ansq49ef9pyd3defntqk5u002yypkljsdredt2c3pytup',
-        hex: '22dfdfca55ece00a97292848d8b7299ac16a71ef51081b7e5068f2d5ab',
-      },
-      {
-        drep_id: 'drep1yte7sk3chauyse8t532sdw0257uwd5rvxgzurg2ht97auagzz57s7',
-        hex: '22f3e85a38bf784864eba45506b9eaa7b8e6d06c3205c1a157597dde75',
-      },
-      {
-        drep_id: 'drep1ytcw6qzpqqclx2yd0zy64ztvlkkhnf6yrzza8whgnq4vz5gh89626',
-        hex: '22f0ed00410031f3288d7889aa896cfdad79a7441885d3bae8982ac151',
-      },
-      {
-        drep_id: 'drep1y2042s3vtxpdp7e60v043vrqp5fgtp2hnwkju64x7ccf2rgvetjkv',
-        hex: '229f55422c5982d0fb3a7b1f58b0600d128585579bad2e6aa6f630950d',
-      },
-      {
-        drep_id: 'drep1y2rm8tr96q2836y3srhfl3ngk8sqza39c9u0c93anmklnlcxe3p9c',
-        hex: '2287b3ac65d01478e89180ee9fc668b1e0017625c178fc163d9eedf9ff',
-      },
-      {
-        drep_id: 'drep1yf3w5wxgp6slvqugrrxqk0c4ktg6z6lyrj5vvu0epmc0u9q2fawj6',
-        hex: '2262ea38c80ea1f6038818cc0b3f15b2d1a16be41ca8c671f90ef0fe14',
-      },
-      {
-        drep_id: 'drep1yt2v0x99yh0ksyv7rp2xjhkzqy6qhn0fms5gmfqejgdvnzcwsetgw',
-        hex: '22d4c798a525df68119e1854695ec201340bcde9dc288da419921ac98b',
-      },
-      {
-        drep_id: 'drep1ygccr4qs075s7ajjxv4nc6ax2km930u0mna6xzxwmlzwujcaczyrp',
-        hex: '223181d4107fa90f7652332b3c6ba655b658bf8fdcfba308cedfc4ee4b',
-      },
-      {
-        drep_id: 'drep1ygqpqgdfk5u0dyl49yae44m7nlf0a0j7e4nvlzajs3954rgf3wcqa',
-        hex: '22001021a9b538f693f5293b9ad77e9fd2febe5ecd66cf8bb2844b4a8d',
-      },
-      {
-        drep_id: 'drep1ygwkyyf3a6gucvlk37rhcutlrtaheupgcd5rvfqc97v6tmsnaesgd',
-        hex: '221d621131ee91cc33f68f877c717f1afb7cf028c3683624182f99a5ee',
-      },
-      {
-        drep_id: 'drep1y26gl2kcpt4ps9lc3efs0l0lhxm7atmhc0kjnugr2w90yxqctpdw4',
-        hex: '22b48faad80aea1817f88e5307fdffb9b7eeaf77c3ed29f103538af218',
-      },
-      {
-        drep_id: 'drep1ytg60fstya0khfndc7l29gujdujhdawgkkea64hehle7aks8lqcxv',
-        hex: '22d1a7a60b275f6ba66dc7bea2a3926f2576f5c8b5b3dd56f9bff3eeda',
-      },
-      {
-        drep_id: 'drep1yfc7z0v37wm4dmvup2l33w8grhedgs3hfq3sa95dh5h3jjcghkuk9',
-        hex: '2271e13d91f3b756ed9c0abf18b8e81df2d4423748230e968dbd2f194b',
-      },
-      {
-        drep_id: 'drep1yt457w37784w7np93t6vk4wrfptrmnnsg4cnvea432cmwfg2pe9l7',
-        hex: '22eb4f3a3ef1eaef4c258af4cb55c348563dce7045713667b58ab1b725',
-      },
-      {
-        drep_id: 'drep1yf0qp8m5e9mdfl8rk90v0x3rgrvyw97ee4jlc2j80l3l8yckwzsgn',
-        hex: '225e009f74c976d4fce3b15ec79a2340d84717d9cd65fc2a477fe3f393',
-      },
-      {
-        drep_id: 'drep1ygg8d9n078fueupj4fzjqzquccyw6vae5uq8qdn9rgppzagrlg88a',
-        hex: '221076966ff1d3ccf032aa4520081cc608ed33b9a7007036651a021175',
-      },
-      {
-        drep_id: 'drep1ygqr6dy6rl0qvr7hnvss9g92pzzt4kfsur7sf8jmy6nytms6s87cz',
-        hex: '22003d349a1fde060fd79b2102a0aa0884bad930e0fd049e5b26a645ee',
-      },
-      {
-        drep_id: 'drep1y2wsprutpljs4dqn7wafhwhse4h0crd7tsn2ek7zk8h4yrsy4d0te',
-        hex: '229d008f8b0fe50ab413f3ba9bbaf0cd6efc0dbe5c26acdbc2b1ef520e',
-      },
-      {
-        drep_id: 'drep1yt26jd7he3slqv3985lfllcqfx928444n52f5q8szm3ra9g6dxxrw',
-        hex: '22d5a937d7cc61f032253d3e9fff00498aa3d6b59d149a00f016e23e95',
-      },
-      {
-        drep_id: 'drep1yg2nrnr27sgfxt3neg60glvf7tr8vfussgz00qmj487sz4gfk6rye',
-        hex: '221531cc6af410932e33ca34f47d89f2c67627908204f78372a9fd0155',
-      },
-      {
-        drep_id: 'drep1yglgx9tzudmq7mazv2q4f5w8msshnrkmyyq4902jvk0zq8c27qszh',
-        hex: '223e831562e3760f6fa2628154d1c7dc21798edb210152bd52659e201f',
-      },
-      {
-        drep_id: 'drep1y2qn0rf74zdk3u8upx2yk8un7tlts5f33uvklx96gq5a32qmwj3xg',
-        hex: '2281378d3ea89b68f0fc09944b1f93f2feb851318f196f98ba4029d8a8',
-      },
-      {
-        drep_id: 'drep1ytmgu92lmachsqzjnnmm48q6pdhhzj35ycw74pu04zg9pxqllw6m7',
-        hex: '22f68e155fdf717800529cf7ba9c1a0b6f714a34261dea878fa8905098',
-      },
-      {
-        drep_id: 'drep1yf220645y558fhsz7jd3anssstxyvd4yn9klprvjgm0sgas8av5jf',
-        hex: '2254a7eab4252874de02f49b1ece1082cc4636a4996df08d9246df0476',
-      },
-      {
-        drep_id: 'drep1yg2rnlwqsytyhssz06p6ypxacarxx4v3xvtcmkm2crnes5cfyhx5s',
-        hex: '221439fdc081164bc2027e83a204ddc74663559133178ddb6ac0e79853',
-      },
-      {
-        drep_id: 'drep1yfhyq6tztjksqqpd5lglc3zr2tn8vylgjh9xzz7n2p4l4lgk3qam3',
-        hex: '226e4069625cad00002da7d1fc444352e67613e895ca610bd3506bfafd',
-      },
-      {
-        drep_id: 'drep1ygkwp3xc58jlgtx437vmn9vp3fv2m3u4eww393yhxmpumcq0je3x5',
-        hex: '222ce0c4d8a1e5f42cd58f99b995818a58adc795cb9d12c49736c3cde0',
-      },
-      {
-        drep_id: 'drep1ytax4rwzvdwamnu67j2uk9z00660lpzcvmlys6266l9kt5c262k7m',
-        hex: '22fa6a8dc2635dddcf9af495cb144f7eb4ff845866fe48695ad7cb65d3',
-      },
-      {
-        drep_id: 'drep1yf6dakmlsleca55xmss06thlnapnu4e2l977dax0yk6nhgsevfd0d',
-        hex: '2274dedb7f87f38ed286dc20fd2eff9f433e572af97de6f4cf25b53ba2',
-      },
-      {
-        drep_id: 'drep1y22swams8xvw30jvd42790xhkqdsv2qehh5p56fhcrkz9gqrqmswp',
-        hex: '22950777703998e8be4c6d55e2bcd7b01b062819bde81a6937c0ec22a0',
-      },
-      {
-        drep_id: 'drep1ytz9782u0n7qe58x02nw2m89a4egr0k9jk50z23k76ylalqzgfqcx',
-        hex: '22c45f1d5c7cfc0cd0e67aa6e56ce5ed7281bec595a8f12a36f689fefc',
-      },
-      {
-        drep_id: 'drep1yff9usc98s9rxvrhrjt44yj33pdwd6nse727n64qk5kcr6sxmjtga',
-        hex: '22525e43053c0a3330771c975a9251885ae6ea70cf95e9eaa0b52d81ea',
-      },
-      {
-        drep_id: 'drep1ygy7rr5lnnchdl0csa3a798z4meweuk6kpmltws4vaxvxvcaa7rl8',
-        hex: '2209e18e9f9cf176fdf88763df14e2aef2ecf2dab077f5ba15674cc333',
-      },
-      {
-        drep_id: 'drep1y2jn2g6gsg9sj7lpmxl3x0e3hmtlq9gmhulny7v5mw7qp6gy8ww0x',
-        hex: '22a5352348820b097be1d9bf133f31bed7f0151bbf3f327994dbbc00e9',
-      },
-      {
-        drep_id: 'drep1yt73a8a38mu6f0wsclj84mctlsr9ajnvftymvyuxrn8jpjcsxfsf0',
-        hex: '22fd1e9fb13ef9a4bdd0c7e47aef0bfc065eca6c4ac9b613861ccf20cb',
-      },
-      {
-        drep_id: 'drep1y2sl7t3z4cxlsmmy7x8wvx3vskce3ptx3k7y2rs26dlh3xcxsdz9y',
-        hex: '22a1ff2e22ae0df86f64f18ee61a2c85b19885668dbc450e0ad37f789b',
-      },
-      {
-        drep_id: 'drep1ygqwhzzmlgeh7yvnfvtfmxcrpd0s8l6ezv7zgda33ewphess6y42m',
-        hex: '2200eb885bfa337f11934b169d9b030b5f03ff59133c2437b18e5c1be6',
-      },
-      {
-        drep_id: 'drep1yfvpdnyexpv3s4ppzeq6u0mn9ym8szk09cm4fv98vr8qkxcwd0g9a',
-        hex: '225816cc9930591854211641ae3f732936780acf2e3754b0a760ce0b1b',
-      },
-      {
-        drep_id: 'drep1ytxhymvft3klrjgtt8m9m8gv5sjhv0ut03z4fxhl6anmm9sxlpkqf',
-        hex: '22cd726d895c6df1c90b59f65d9d0ca425763f8b7c45549affd767bd96',
-      },
-      {
-        drep_id: 'drep1ygpmm3ufdh048lfej9q77ae7ferxfw6fg2ck9mmraxnxq8s3wdywp',
-        hex: '2203bdc7896ddf53fd399141ef773e4e4664bb4942b162ef63e9a6601e',
-      },
-      {
-        drep_id: 'drep1ytd3hs7rlxwwdzthe6hj026dmyt3y0heuulctscyydh2kgc9me7as',
-        hex: '22db1bc3c3f99ce68977ceaf27ab4dd917123ef9e73f85c304236eab23',
-      },
-      {
-        drep_id: 'drep1ytmtzs0rt5gq8u4s32mh40g0xuru0zs4veqkw76alqqh0hq52jgwm',
-        hex: '22f6b141e35d1003f2b08ab77abd0f3707c78a156641677b5df80177dc',
-      },
-      {
-        drep_id: 'drep1y23y32wq2047y59509qyvjutk7dmqdgv09kkvegrh8r6elczx5rwf',
-        hex: '22a248a9c053ebe250b47940464b8bb79bb0350c796d666503b9c7acff',
-      },
-      {
-        drep_id: 'drep1y2c8t4k0qvhmar7ysmtdvwcgeej3jxzeum8s28ecxyl88xsuraxwf',
-        hex: '22b075d6cf032fbe8fc486d6d63b08ce65191859e6cf051f38313e739a',
-      },
-      {
-        drep_id: 'drep1ygln6j5yhqqtxn4cf3s4r224ehvz8g9encacsmrjtwrknegzsmh5a',
-        hex: '223f3d4a84b800b34eb84c6151a955cdd823a0b99e3b886c725b8769e5',
-      },
-      {
-        drep_id: 'drep1yfm66g77aau5r06j0xm4nc4ljf8v2hnkdp6hcs8mwzxnulslc2ecs',
-        hex: '2277ad23deef7941bf5279b759e2bf924ec55e7668757c40fb708d3e7e',
-      },
-      {
-        drep_id: 'drep1ytee8ue66qdqkfquq5c9hld7trhxvqdra5plfhyuragcfsgrqen4n',
-        hex: '22f393f33ad01a0b241c05305bfdbe58ee6601a3ed03f4dc9c1f5184c1',
-      },
-      {
-        drep_id: 'drep1ygymv6g9kxrcjpcvlkaxeeq4n0esjyc8rdar43lzs75ncrqa6ep3r',
-        hex: '2209b66905b18789070cfdba6ce4159bf30913071b7a3ac7e287a93c0c',
-      },
-      {
-        drep_id: 'drep1yw9zlct3e7vtjlfklvh2050lr78t55cavfjahjhnh5v3e7s2h3c8k',
-        hex: '238a2fe171cf98b97d36fb2ea7d1ff1f8eba531d6265dbcaf3bd191cfa',
-      },
-      {
-        drep_id: 'drep1yfkg5ryqwaleunwqg0dtcj8g8yw8sgd9kskg2zlzdr8355gpghcvv',
-        hex: '226c8a0c80777f9e4dc043dabc48e8391c7821a5b42c850be268cf1a51',
-      },
-      {
-        drep_id: 'drep1ytwmwvtd0a8lr45ssner2tjxzv5y8q03w3606yeald9mdmgmwecja',
-        hex: '22ddb7316d7f4ff1d69084f2352e4613284381f17474fd133dfb4bb6ed',
-      },
-      {
-        drep_id: 'drep1y23wflfehz8ek539jtscdu3f7ua3g8axk964c65x242v7aqktt0cc',
-        hex: '22a2e4fd39b88f9b522592e186f229f73b141fa6b1755c6a865554cf74',
-      },
-      {
-        drep_id: 'drep1yfx9wupcwgrepdepkqfw4ud2lnhqedv37t3pduhrt9sutdsqqen0z',
-        hex: '224c577038720790b721b012eaf1aafcee0cb591f2e216f2e35961c5b6',
-      },
-      {
-        drep_id: 'drep1ytwz2ryz6d4636tn733wlayx7s4aene6e9h9n0xxmw2s29qzq9t08',
-        hex: '22dc250c82d36ba8e973f462eff486f42bdccf3ac96e59bcc6db950514',
-      },
-      {
-        drep_id: 'drep1yfrud5mk40ttv4z5l4ltvcgfstmjzwyv73hczmmpue4dv0gus8kge',
-        hex: '2247c6d376abd6b65454fd7eb6610982f721388cf46f816f61e66ad63d',
-      },
-      {
-        drep_id: 'drep1yf7rhr6k8gfecdn8z5r38uqyaafcfr785lsgzsvc7ye3m9g3z20kj',
-        hex: '227c3b8f563a139c3667150713f004ef53848fc7a7e0814198f1331d95',
-      },
-      {
-        drep_id: 'drep1ygfa6qqqzy6ppfz8neuck5j4hcrfa2pj0gnkq34rj7jh8vqpx5f0k',
-        hex: '2213dd0000113410a4479e798b5255be069ea8327a276046a397a573b0',
-      },
-      {
-        drep_id: 'drep1yfzwh6dd7pdf2hhpjhfj2zml52nwna5e66glqk2wsqegrjs037657',
-        hex: '2244ebe9adf05a955ee195d3250b7fa2a6e9f699d691f0594e803281ca',
-      },
-      {
-        drep_id: 'drep1ygwk39j52lh9kdkk2hxyyt3upa5r8e54e6vzj6hzfjuk38gpu3pp8',
-        hex: '221d68965457ee5b36d655cc422e3c0f6833e695ce98296ae24cb9689d',
-      },
-      {
-        drep_id: 'drep1yt27gd2vx376u93n0w70wtrsh90zfc3jljgxq6jfnvztqkcuzwewn',
-        hex: '22d5e4354c347dae16337bbcf72c70b95e24e232fc90606a499b04b05b',
-      },
-      {
-        drep_id: 'drep1y25fwf6t6ndp9jeassrwkfaeksgqckvvz5a8exnm9h9hm8qvxeryd',
-        hex: '22a897274bd4da12cb3d8406eb27b9b4100c598c153a7c9a7b2dcb7d9c',
-      },
-      {
-        drep_id: 'drep1yf2le3jq74jk4gaw4a54yc5zplhhxvylv2czpqcgm6cwehqhh53p9',
-        hex: '2255fcc640f5656aa3aeaf695262820fef73309f62b0208308deb0ecdc',
-      },
-      {
-        drep_id: 'drep1yff65vq4g4jcr80r2tqawmdezyrv64x0728zfcf04nvlssc9nf9t3',
-        hex: '2253aa30154565819de352c1d76db91106cd54cff28e24e12facd9f843',
-      },
-      {
-        drep_id: 'drep1yt0n05825f7s4w5tvykgmdq3n6w50w5cuam74x3nhpx2fqcc4m226',
-        hex: '22df37d0eaa27d0aba8b612c8db4119e9d47ba98e777ea9a33b84ca483',
-      },
-      {
-        drep_id: 'drep1y2zpa7e9f23g7snuhfqss73ufeshsqhdt4qqfu74p9y4kfqcpsxym',
-        hex: '22841efb254aa28f427cba41087a3c4e617802ed5d4004f3d509495b24',
-      },
-      {
-        drep_id: 'drep1ytwx8am2dnqn5umayy5pg0cw80rzem5v35pxnz30uxkqr6qlntcwx',
-        hex: '22dc63f76a6cc13a737d2128143f0e3bc62cee8c8d02698a2fe1ac01e8',
-      },
-      {
-        drep_id: 'drep1y2dp66yme5pf7ktvxagrcwltpfr2rwwymcyq35lc4nuyj2g8durwl',
-        hex: '229a1d689bcd029f596c37503c3beb0a46a1b9c4de0808d3f8acf84929',
-      },
-      {
-        drep_id: 'drep1y2zj567cky5sj03farq3pmdlxvvr5e2cx86dqk39l434yzgee9ulp',
-        hex: '22852a6bd8b129093e29e8c110edbf33183a655831f4d05a25fd635209',
-      },
-      {
-        drep_id: 'drep1yt4m3d3jpqqzv92pp25qysxqu0fggh9wkhpaey4szdxj3qslpgxjx',
-        hex: '22ebb8b63208002615410aa80240c0e3d2845caeb5c3dc92b0134d2882',
+        amount: expect.toBeAdaQuantity(),
+        has_script: false,
+        retired: expect.any(Boolean),
+        expired: expect.any(Boolean),
+        last_active_epoch: expect.toBeNullableEpochNumber(),
+        metadata: drepListMetadata,
       },
     ],
   },

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -1,4 +1,5 @@
 import { getUnixTime, isValid } from 'date-fns';
+import { expect } from 'vitest';
 import { isBlockchainStateSetupEnabled } from './utils.js';
 import { getConfig } from './config.js';
 
@@ -210,6 +211,40 @@ export const toBeCurrentEpochNumber = (received: number) => {
     message: () => `Expected value ${received} to be within range for an epoch <${min}, ${max}>`,
   };
 };
+
+export const toBeNullableEpochNumber = (received: number | null) => {
+  if (received === null) {
+    return { pass: true, message: () => `Expected value to be null or a valid epoch number` };
+  }
+
+  return toBeEpochNumber(received);
+};
+
+/**
+ * Shape matcher for the `metadata` field of each `/governance/dreps` list item.
+ * Content correctness (json_metadata, bytes, hash) is covered by the dedicated
+ * `/governance/dreps/{drep_id}/metadata` tests, so here we only assert one of the
+ * three valid shapes:
+ *  - `null` when the DRep has no registered anchor,
+ *  - resolved metadata (anchor registered and fetched), or
+ *  - an off-chain fetch error (anchor registered, fetch failed).
+ */
+export const drepListMetadata = expect.toBeOneOf([
+  null,
+  {
+    url: expect.any(String),
+    hash: expect.any(String),
+    json_metadata: expect.any(Object),
+    bytes: expect.any(String),
+  },
+  {
+    url: expect.any(String),
+    hash: expect.any(String),
+    json_metadata: null,
+    bytes: null,
+    error: { code: expect.any(String), message: expect.any(String) },
+  },
+]);
 
 export const toBeEpochSlotNumber = (received: number) => {
   // Note: missing inversion (could be handled with this.isNot),

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -22,6 +22,7 @@ import {
   toBeStakeAddress,
   toBeCurrentBlockHeight,
   toBeCurrentEpochNumber,
+  toBeNullableEpochNumber,
 } from './matchers.js';
 import { isBlockchainStateSetupEnabled } from './utils.js';
 
@@ -79,4 +80,5 @@ expect.extend({
   toBeStakeAddress,
   toBeCurrentBlockHeight,
   toBeCurrentEpochNumber,
+  toBeNullableEpochNumber,
 });

--- a/src/types/vitest.d.ts
+++ b/src/types/vitest.d.ts
@@ -39,6 +39,7 @@ declare module 'vitest' {
     toBeStakeAddress(): void;
     toBeCurrentBlockHeight(options?: { toleranceInBlocks?: number }): void;
     toBeCurrentEpochNumber(): void;
+    toBeNullableEpochNumber(): void;
   }
 }
 


### PR DESCRIPTION
## Summary

Updates tests for the extended `/governance/dreps` endpoint ([blockfrost-backend-ryo#341](https://github.com/blockfrost/blockfrost-backend-ryo/pull/341)).

### List fixtures (`governance/dreps`)
- Extended each list item with the new fields: `amount`, `has_script`, `retired`, `expired`, `last_active_epoch`, `metadata`.
- Trimmed to **10 items** via `?count=10`.
- Volatile fields use matchers (`amount` → `toBeAdaQuantity`, `last_active_epoch` → `toBeNullableEpochNumber`, booleans → `expect.any(Boolean)`).
- `metadata` is asserted by a shared `toBeOneOf` shape matcher (`null` | resolved | error) — **not** hardcoded, since content changes often and correctness is already covered by the dedicated `/metadata` endpoint tests.

### New query-param tests (shared in `common/governance/dreps.ts`, run against all 3 networks)
- `order_by=amount` asc + desc — fetches page 1 **and** page 2 and asserts the concatenation is sorted, so ordering is verified across the page boundary (not just within a page).
- `retired=true` / `retired=false`
- `expired=true` / `expired=false`
- combined `retired=false&expired=false`

### Supporting
- Added `toBeNullableEpochNumber` and `drepListMetadata` matchers (`src/matchers.ts`), registered in `src/setup.ts`, typed in `src/types/vitest.d.ts`.

## Verification
- `type-check`, `lint`, and unit tests pass.
- All new list / sort / filter tests pass against the preprod, mainnet, and preview **dev** backends.

## Notes
- The `metadata` matcher expects `metadata: null` for no-anchor DReps — requires the backend change that returns `null` instead of an object with nulled fields.
- Sanity-checked (outside tests): list data matches `/dreps/:id` and `/metadata` (hash), and basic fields match koios (`amount`, `has_script`; `hex` differs only by the CIP-129 header byte).