### PR TITLE
fix: loosen metadata error messages to substring match

### DIFF
--- a/src/fixtures/mainnet/governance/dreps/drep-metadata.ts
+++ b/src/fixtures/mainnet/governance/dreps/drep-metadata.ts
@@ -1,3 +1,5 @@
+import { expect } from 'vitest';
+
 export default [
   {
     id: 'governance-drep-metadata_cbc2a3b2507a',
@@ -229,8 +231,9 @@ export default [
       bytes: null,
       error: {
         code: 'HTTP_RESPONSE_ERROR',
-        message:
+        message: expect.stringContaining(
           'Error Offchain Voting Anchor: HTTP Response error from https://adatree.io: expected JSON, but got : "text/html; charset=UTF-8"',
+        ),
       },
     },
   },

--- a/src/fixtures/preprod/governance/dreps/drep-metadata.ts
+++ b/src/fixtures/preprod/governance/dreps/drep-metadata.ts
@@ -1,3 +1,5 @@
+import { expect } from 'vitest';
+
 export default [
   {
     id: 'governance-drep-metadata_768fb8371a01',
@@ -240,8 +242,9 @@ export default [
       bytes: null,
       error: {
         code: 'HTTP_RESPONSE_ERROR',
-        message:
+        message: expect.stringContaining(
           'Error Offchain Voting Anchor: HTTP Response error from https://example.com/my-drep-info.json resulted in HTTP status code : 404 "Not Found"',
+        ),
       },
     },
   },

--- a/src/fixtures/preprod/governance/proposals/hash-cert-index-metadata.ts
+++ b/src/fixtures/preprod/governance/proposals/hash-cert-index-metadata.ts
@@ -1,3 +1,4 @@
+import { expect } from 'vitest';
 import { error_404 } from '../../../errors/index.js';
 
 export default [
@@ -25,8 +26,11 @@ export default [
       bytes: null,
       error: {
         code: 'HASH_MISMATCH',
-        message:
+        // Substring match — the backend may wrap the original hash-mismatch
+        // message with additional gateway-error context.
+        message: expect.stringContaining(
           'Hash mismatch when fetching metadata from https://raw.githubusercontent.com/logical-mechanism/dRep/main/scripts/data/actions/simple.action.json. Expected "b0ea2fb2fb9a573b8d8b856f861053382e1ef0ca6ecb76cec39c53e94f2c5a29" but got "25a678e8f8dc511d96005aebb34f8cba23f7bf8a032d394691cb60f6d1c2f1a3".',
+        ),
       },
     },
   },

--- a/src/fixtures/preprod/pools/pool-id.ts
+++ b/src/fixtures/preprod/pools/pool-id.ts
@@ -331,8 +331,11 @@ export default [
       homepage: null,
       error: {
         code: 'HASH_MISMATCH',
-        message:
+        // Substring match — the backend may wrap the original hash-mismatch
+        // message with additional gateway-error context.
+        message: expect.stringContaining(
           'Hash mismatch when fetching metadata from https://tinyurl.com/39a7pnv5. Expected "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" but got "b123ea83d1f87afcb95a76661be508b37a0957c7fa95baa883a80d1203ffcd94".',
+        ),
       },
     },
   },

--- a/src/fixtures/preview/governance/dreps/drep-metadata.ts
+++ b/src/fixtures/preview/governance/dreps/drep-metadata.ts
@@ -1,3 +1,5 @@
+import { expect } from 'vitest';
+
 export default [
   {
     id: 'governance-drep-metadata_db851404fc0f',
@@ -93,8 +95,9 @@ export default [
       bytes: null,
       error: {
         code: 'HTTP_RESPONSE_ERROR',
-        message:
+        message: expect.stringContaining(
           'Error Offchain Voting Anchor: HTTP Response error from https://bit.ly/3zCH2HL: expected JSON, but got : "text/html; charset=utf-8"',
+        ),
       },
     },
   },
@@ -113,8 +116,11 @@ export default [
       bytes: null,
       error: {
         code: 'HASH_MISMATCH',
-        message:
+        // Substring match — the backend may wrap the original hash-mismatch
+        // message with additional gateway-error context.
+        message: expect.stringContaining(
           'Hash mismatch when fetching metadata from https://raw.githubusercontent.com/mirceahasegan/drep-registry/main/Mircea.jsonld. Expected "603f3202d8d1c15f54adfd944a437e7c0b6183a4ec3c04c0dec3faadb7825ccb" but got "3a0593d40c051d06780a6f4e70643ac61807e074377a1937ab2e7bad9a1ac08a".',
+        ),
       },
     },
   },

--- a/src/fixtures/preview/pools/pool-id.ts
+++ b/src/fixtures/preview/pools/pool-id.ts
@@ -420,8 +420,11 @@ export default [
       homepage: null,
       error: {
         code: 'HASH_MISMATCH',
-        message:
+        // Substring match — the backend may wrap the original hash-mismatch
+        // message with additional gateway-error context.
+        message: expect.stringContaining(
           'Hash mismatch when fetching metadata from https://tinyurl.com/39a7pnv5. Expected "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" but got "b123ea83d1f87afcb95a76661be508b37a0957c7fa95baa883a80d1203ffcd94".',
+        ),
       },
     },
   },


### PR DESCRIPTION
## Summary
The backend now wraps the original `HASH_MISMATCH` / `HTTP_RESPONSE_ERROR` message with additional gateway-error context (e.g. multiple IPFS gateway failures concatenated). The current fixtures assert the message via exact-equality on `error.message`, which fails as soon as that extra context appears.

Switch the affected metadata-error fixtures from exact match to `expect.stringContaining(...)` so we still assert the original error text appears, while tolerating extra wrapping.

## Example failure that motivated this
Preview drep metadata (HASH_MISMATCH):
- **expected:** `Hash mismatch when fetching metadata from https://raw.githubusercontent.com/mirceahasegan/drep-registry/main/Mircea.jsonld. Expected "603f3..." but got "3a059...".`
- **received:** `Error Offchain Voting Anchor: List of errors for each ipfs gateway: Hash mismatch when fetching metadata from https://raw.githubusercontent.com/mirceahasegan/drep-registry/main/Mircea.jsonld. Expected "603f3..." but got "3a059...".Error Offchain Voting Anchor: HTTP Response error from https://ipfs.io/ipfs/f0155... resulted in HTTP status code : 504 "Gateway Timeout"Error Offchain Voting Anchor: HTTP Response error from https://ipfs.blockfrost.dev/ipfs/f0155... resulted in HTTP status code : 502 "Bad Gateway"`

The original error is still in the wrapped message, just no longer the entire value.

## Affected fixtures
- `preview/governance/dreps/drep-metadata.ts`
- `preprod/governance/dreps/drep-metadata.ts`
- `mainnet/governance/dreps/drep-metadata.ts`
- `preprod/governance/proposals/hash-cert-index-metadata.ts`
- `preview/pools/pool-id.ts`
- `preprod/pools/pool-id.ts`

## Test plan
- [x] Locally re-ran `governance drep metadata - HASH_MISMATCH` against preview prod core — passes.
- [x] Locally re-ran `governance proposal info_action metadata (hash mismatch, only basic info returned)` against preprod dev backend1 — passes.
- [ ] CI run on the consuming internal repo (`blockfrost-tests-internal`) after submodule pointer bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)