### PR TITLE
fix(mainnet): refresh AzureADA pool owners to latest registration cert

### DIFF
--- a/src/fixtures/mainnet/pools/pool-id.ts
+++ b/src/fixtures/mainnet/pools/pool-id.ts
@@ -64,9 +64,8 @@ export default [
       reward_account: 'stake1u85438ffegdckx7ue4dnlnmam3y9pj706ca5ty6k7hfw66cr88h5z',
       owners: [
         'stake1uy5z0sz2rp8cd2r0m6vencdnt9m0y99eack2yryrtpxn60qknvq55',
+        'stake1u9508fvrykz9nqfhgefwulyd065u33uwlq7fncmkvvwyteceqc9pc',
         'stake1uxt4xh7hxkkz6la2ndnlnwg07djsncvdptqmz8t8jqc9zjgj8gac4',
-        'stake1uxeum36f74cmyjm9k7lvvjnzwts76h529hrv036frzrhw2c76ghv0',
-        'stake1u8tln79d7040nxum39agnc8v2e473khmkn9jmc9sljgyksszeft6x',
         'stake1u85438ffegdckx7ue4dnlnmam3y9pj706ca5ty6k7hfw66cr88h5z',
         'stake1u8ahk5y0kp3gdtuur9tu0llj6hk85kfhmca5ngnpnxmaa9qnpeqct',
       ],


### PR DESCRIPTION
## Context

The integration test `pools endpoints > [pools/pool_id - pool with more owners]` (`pool108zdflss3ayqlm5c7vr6mtqj2uwl99vk28ur8dv4zswdzt6yauc`, AzureADA / AZUR) was failing because the fixture's `owners` array no longer matches the chain.

AzureADA re-registered the pool on **2026-05-31** in tx `a57e9ed7d406a5c577ad16daa1d393f07f452ea16f05ae374bd9485307d50e05` (active in epoch 637), changing the declared owner set:

```diff
+ stake1u9508fvrykz9nqfhgefwulyd065u33uwlq7fncmkvvwyteceqc9pc
- stake1uxeum36f74cmyjm9k7lvvjnzwts76h529hrv036frzrhw2c76ghv0
- stake1u8tln79d7040nxum39agnc8v2e473khmkn9jmc9sljgyksszeft6x
```

### Example failure

- https://github.com/blockfrost/blockfrost-platform/actions/runs/27617693309/job/81657754319?pr=586