### PR TITLE
feat: add fixtures for /scripts/:script_hash/utxos

### DIFF
--- a/src/fixtures/mainnet/index.ts
+++ b/src/fixtures/mainnet/index.ts
@@ -69,6 +69,7 @@ import scriptsHash from './scripts/hash.js';
 import scriptsHashJson from './scripts/hash-json.js';
 import scriptsHashCbor from './scripts/hash-cbor.js';
 import scriptsHashRedeemers from './scripts/hash-redeemers.js';
+import scriptsHashUtxos from './scripts/hash-utxos.js';
 import txsLabels from './txs/tx.js';
 import utilsTxsEvaluate from './utils/txs-evaluate.js';
 import utilsTxsEvaluateUtxos from './utils/txs-evaluate-utxos.js';
@@ -184,6 +185,7 @@ export const mainnetFixtures = {
     ...scriptsHashJson,
     ...scriptsHashCbor,
     ...scriptsHashRedeemers,
+    ...scriptsHashUtxos,
   ],
   governance: [
     ...governanceDrep,

--- a/src/fixtures/mainnet/scripts/hash-utxos.ts
+++ b/src/fixtures/mainnet/scripts/hash-utxos.ts
@@ -1,0 +1,43 @@
+import { error_404 } from '../../errors/index.js';
+import { getPaginationFixtures } from '../../../index.js';
+
+const paginationFixtures = getPaginationFixtures(
+  'scripts/ea153b5d4864af15a1079a94a0e2486d6376fa28aafad272d15b243a/utxos',
+);
+
+export default [
+  ...paginationFixtures,
+  {
+    // Stable, long-lived reference script (CIP-33) deployed at its own script
+    // address since 2023-08; the single UTxO is never spent.
+    id: 'scripts-script-hash-utxos-script-held-as-a-reference-script_47a0a932d5c3',
+    testName: 'scripts/:script_hash/utxos - script held as a reference script',
+    endpoints: ['scripts/ea153b5d4864af15a1079a94a0e2486d6376fa28aafad272d15b243a/utxos'],
+    response: [
+      {
+        address:
+          'addr1z84p2w6afpj279dpq7dffg8zfpkkxah69z4045nj69djgwj75jq4yvpskgayj55xegdp30g5rfynax66r8vgn9fldnds7gwhs9',
+        tx_hash: '83ad75f5f4c1077b8df49cd3c780f51e66355ba7e6a9f27b1d9150cba00bfedd',
+        output_index: 0,
+        amount: [{ unit: 'lovelace', quantity: '11593900' }],
+        block: 'b0648534f7b795ea193278c3a96c9957c78837acfe9877960c82791b9361766a',
+        data_hash: null,
+        inline_datum: null,
+        reference_script_hash: 'ea153b5d4864af15a1079a94a0e2486d6376fa28aafad272d15b243a',
+      },
+    ],
+  },
+  {
+    // Valid on-chain script that is not used as a reference script anywhere.
+    id: 'scripts-script-hash-utxos-script-not-held-as-a-reference-script-empty_48b3edda3508',
+    testName: 'scripts/:script_hash/utxos - script not held as a reference script (empty)',
+    endpoints: ['scripts/4f590a3d80ae0312bad0b64d540c3ff5080e77250e9dbf5011630016/utxos'],
+    response: [],
+  },
+  {
+    id: 'scripts-script-hash-utxos-unknown-script-hash_5ff58ba04810',
+    testName: 'scripts/:script_hash/utxos - unknown script hash',
+    endpoints: ['scripts/0000000000000000000000000000000000000000000000000000dead/utxos'],
+    response: error_404,
+  },
+];

--- a/src/fixtures/preprod/index.ts
+++ b/src/fixtures/preprod/index.ts
@@ -71,6 +71,7 @@ import scriptsHash from './scripts/hash.js';
 import scriptsHashJson from './scripts/hash-json.js';
 import scriptsHashCbor from './scripts/hash-cbor.js';
 import scriptsHashRedeemers from './scripts/hash-redeemers.js';
+import scriptsHashUtxos from './scripts/hash-utxos.js';
 
 import tsxMetadata from './txs/tx-metadata.js';
 import txsTx from './txs/tx.js';
@@ -196,6 +197,7 @@ export const preprodFixtures = {
     ...scriptsHashJson,
     ...scriptsHashCbor,
     ...scriptsHashRedeemers,
+    ...scriptsHashUtxos,
   ],
   swaps: [...swapsAsset],
   tx: [...txSubmit],

--- a/src/fixtures/preprod/scripts/hash-utxos.ts
+++ b/src/fixtures/preprod/scripts/hash-utxos.ts
@@ -1,0 +1,43 @@
+import { error_404 } from '../../errors/index.js';
+import { getPaginationFixtures } from '../../../index.js';
+
+const paginationFixtures = getPaginationFixtures(
+  'scripts/12108f654f8a58118e06fa8cccf5b6def94b07eab73f03ae0dbf8e3d/utxos',
+);
+
+export default [
+  ...paginationFixtures,
+  {
+    // Stable, long-lived reference script (CIP-33) deployed at its own script
+    // address since 2024-02; the single UTxO is never spent.
+    id: 'scripts-script-hash-utxos-script-held-as-a-reference-script_ea6abbff237b',
+    testName: 'scripts/:script_hash/utxos - script held as a reference script',
+    endpoints: ['scripts/12108f654f8a58118e06fa8cccf5b6def94b07eab73f03ae0dbf8e3d/utxos'],
+    response: [
+      {
+        address:
+          'addr_test1zqfpprm9f799syvwqmagen84km00jjc8a2mn7qawpklcu0gk5syjxqa7fzmywlp2qkf63n2g8jsy22z9sh45s5lggunqwjqqvk',
+        tx_hash: 'a84b6cbbfa86cd0fe4997b0b3c2bc26cdb647f2c99902895c321dd5b125ba027',
+        output_index: 0,
+        amount: [{ unit: 'lovelace', quantity: '22166330' }],
+        block: 'b90a16462631b335301bbb0514435c6a615db5a8de8bd38ce683ed1fdd9e5d68',
+        data_hash: null,
+        inline_datum: null,
+        reference_script_hash: '12108f654f8a58118e06fa8cccf5b6def94b07eab73f03ae0dbf8e3d',
+      },
+    ],
+  },
+  {
+    // Valid on-chain script that is not used as a reference script anywhere.
+    id: 'scripts-script-hash-utxos-script-not-held-as-a-reference-script-empty_1ad16c27d255',
+    testName: 'scripts/:script_hash/utxos - script not held as a reference script (empty)',
+    endpoints: ['scripts/be349fa49a9ce173a999e4229efbb3983c86c8183d75305728d7d9ff/utxos'],
+    response: [],
+  },
+  {
+    id: 'scripts-script-hash-utxos-unknown-script-hash_5ff58ba04810',
+    testName: 'scripts/:script_hash/utxos - unknown script hash',
+    endpoints: ['scripts/0000000000000000000000000000000000000000000000000000dead/utxos'],
+    response: error_404,
+  },
+];

--- a/src/fixtures/preprod/scripts/hash-utxos.ts
+++ b/src/fixtures/preprod/scripts/hash-utxos.ts
@@ -28,6 +28,35 @@ export default [
     ],
   },
   {
+    // Multiple stable UTxOs (deployed 2023-04) hold the same script as a
+    // reference script; both sit at the same script address and are unspent.
+    id: 'scripts-script-hash-utxos-multiple-utxos-hold-the-same-reference-script_471d8725760e',
+    testName: 'scripts/:script_hash/utxos - multiple utxos hold the same reference script',
+    endpoints: ['scripts/8404e49607680e3cd6f24029a697cc8a8c32cf340c5b9ef155fee363/utxos'],
+    response: [
+      {
+        address: 'addr_test1wzzqfeykqa5qu0xk7fqznf5hej9gcvk0xsx9h8h32hlwxccqxy5ad',
+        tx_hash: '171de32825c7ec95095d8d2cace20e4a246fb68dafb970e08e7b2a68bca1790e',
+        output_index: 0,
+        amount: [{ unit: 'lovelace', quantity: '28148610' }],
+        block: '61ee967c3079c1e31d1ccf25d787ea028540a31626c1dd9e9234c00c847071e5',
+        data_hash: '923918e403bf43c34b4ef6b48eb2ee04babed17320d8d1b9ff9ad086e86f44ec',
+        inline_datum: null,
+        reference_script_hash: '8404e49607680e3cd6f24029a697cc8a8c32cf340c5b9ef155fee363',
+      },
+      {
+        address: 'addr_test1wzzqfeykqa5qu0xk7fqznf5hej9gcvk0xsx9h8h32hlwxccqxy5ad',
+        tx_hash: '1e491f556a3afbcb669fc4b0ce1a3fdb541613b3641fb7ac1d2dfd6484a09585',
+        output_index: 0,
+        amount: [{ unit: 'lovelace', quantity: '28148610' }],
+        block: 'fdd8e3b31b71f9963136408b75e3bc291f88968290add0d80e1515f15990cb79',
+        data_hash: '923918e403bf43c34b4ef6b48eb2ee04babed17320d8d1b9ff9ad086e86f44ec',
+        inline_datum: null,
+        reference_script_hash: '8404e49607680e3cd6f24029a697cc8a8c32cf340c5b9ef155fee363',
+      },
+    ],
+  },
+  {
     // Valid on-chain script that is not used as a reference script anywhere.
     id: 'scripts-script-hash-utxos-script-not-held-as-a-reference-script-empty_1ad16c27d255',
     testName: 'scripts/:script_hash/utxos - script not held as a reference script (empty)',

--- a/src/fixtures/preview/index.ts
+++ b/src/fixtures/preview/index.ts
@@ -72,6 +72,7 @@ import scriptsHash from './scripts/hash.js';
 import scriptsHashJson from './scripts/hash-json.js';
 import scriptsHashCbor from './scripts/hash-cbor.js';
 import scriptsHashRedeemers from './scripts/hash-redeemers.js';
+import scriptsHashUtxos from './scripts/hash-utxos.js';
 
 import txsTx from './txs/tx.js';
 import txsDelegations from './txs/tx-delegations.js';
@@ -182,6 +183,7 @@ export const previewFixtures = {
     ...scriptsHashJson,
     ...scriptsHashCbor,
     ...scriptsHashRedeemers,
+    ...scriptsHashUtxos,
   ],
   governance: [
     ...governanceDrep,

--- a/src/fixtures/preview/scripts/hash-utxos.ts
+++ b/src/fixtures/preview/scripts/hash-utxos.ts
@@ -27,6 +27,35 @@ export default [
     ],
   },
   {
+    // Multiple stable UTxOs (deployed 2022-11) hold the same script as a
+    // reference script; both sit at the same script address and are unspent.
+    id: 'scripts-script-hash-utxos-multiple-utxos-hold-the-same-reference-script_d53b9c8ddd91',
+    testName: 'scripts/:script_hash/utxos - multiple utxos hold the same reference script',
+    endpoints: ['scripts/4cb17f742d599acb0ad1df2f1cbc282f6e3e6d8506142e6cf8824846/utxos'],
+    response: [
+      {
+        address: 'addr_test1wrpn0ad8rj3pgfpzae5tghpf325nyvh94zfkj3kzgvxzvcc2zuac6',
+        tx_hash: '34c49e3f641e5ab53efb6bf5f23a914c7bace7625af8c0cf8560b53a9acfc7c2',
+        output_index: 0,
+        amount: [{ unit: 'lovelace', quantity: '49659820' }],
+        block: 'e8ad910d114206163b5c7277110f32e169ce1b4079b1b853a32ebbdc30bb3965',
+        data_hash: '923918e403bf43c34b4ef6b48eb2ee04babed17320d8d1b9ff9ad086e86f44ec',
+        inline_datum: null,
+        reference_script_hash: '4cb17f742d599acb0ad1df2f1cbc282f6e3e6d8506142e6cf8824846',
+      },
+      {
+        address: 'addr_test1wrpn0ad8rj3pgfpzae5tghpf325nyvh94zfkj3kzgvxzvcc2zuac6',
+        tx_hash: '300fdcf1a58ba86f688ab7319d61a219d23bc2f01ad5fce56130ba78222ff1f7',
+        output_index: 0,
+        amount: [{ unit: 'lovelace', quantity: '49659820' }],
+        block: '35b0e7818bbb42e282580c405e58479866d70fbc0123fc2120466f06260f3694',
+        data_hash: '923918e403bf43c34b4ef6b48eb2ee04babed17320d8d1b9ff9ad086e86f44ec',
+        inline_datum: null,
+        reference_script_hash: '4cb17f742d599acb0ad1df2f1cbc282f6e3e6d8506142e6cf8824846',
+      },
+    ],
+  },
+  {
     // Valid on-chain script that is not used as a reference script anywhere.
     id: 'scripts-script-hash-utxos-script-not-held-as-a-reference-script-empty_10ef6940dc10',
     testName: 'scripts/:script_hash/utxos - script not held as a reference script (empty)',

--- a/src/fixtures/preview/scripts/hash-utxos.ts
+++ b/src/fixtures/preview/scripts/hash-utxos.ts
@@ -1,0 +1,42 @@
+import { error_404 } from '../../errors/index.js';
+import { getPaginationFixtures } from '../../../index.js';
+
+const paginationFixtures = getPaginationFixtures(
+  'scripts/5e26aa4b932d656580a16e1002425b3a9485cdf2f71fc303c955e119/utxos',
+);
+
+export default [
+  ...paginationFixtures,
+  {
+    // Stable, long-lived reference script (CIP-33) deployed at its own script
+    // address since 2023-06; the single UTxO is never spent.
+    id: 'scripts-script-hash-utxos-script-held-as-a-reference-script_e71fcec273ed',
+    testName: 'scripts/:script_hash/utxos - script held as a reference script',
+    endpoints: ['scripts/5e26aa4b932d656580a16e1002425b3a9485cdf2f71fc303c955e119/utxos'],
+    response: [
+      {
+        address: 'addr_test1wzjwvgn5k3m9ekmrceh6c0azywhh3d8l5jq09tpm7cwp0es5ksry9',
+        tx_hash: 'a3839e95369a0440cef381078e7d28238ae0766b479623450220365866229466',
+        output_index: 0,
+        amount: [{ unit: 'lovelace', quantity: '14102320' }],
+        block: '16469d4585be8dc45d87f6c1bf17ee42426d68225eebbd263c97cc4debab1f0e',
+        data_hash: '923918e403bf43c34b4ef6b48eb2ee04babed17320d8d1b9ff9ad086e86f44ec',
+        inline_datum: null,
+        reference_script_hash: '5e26aa4b932d656580a16e1002425b3a9485cdf2f71fc303c955e119',
+      },
+    ],
+  },
+  {
+    // Valid on-chain script that is not used as a reference script anywhere.
+    id: 'scripts-script-hash-utxos-script-not-held-as-a-reference-script-empty_10ef6940dc10',
+    testName: 'scripts/:script_hash/utxos - script not held as a reference script (empty)',
+    endpoints: ['scripts/c22560ac64be051102d6d1cfe5b9b82eb6af4f00dd3806e5cd82e837/utxos'],
+    response: [],
+  },
+  {
+    id: 'scripts-script-hash-utxos-unknown-script-hash_5ff58ba04810',
+    testName: 'scripts/:script_hash/utxos - unknown script hash',
+    endpoints: ['scripts/0000000000000000000000000000000000000000000000000000dead/utxos'],
+    response: error_404,
+  },
+];


### PR DESCRIPTION
## Summary

Adds test fixtures for the new `GET /scripts/{script_hash}/utxos` endpoint ([blockfrost-backend-ryo#343](https://github.com/blockfrost/blockfrost-backend-ryo/pull/343)), which lists the UTxOs that hold a given script as a **reference script (CIP-33)** — across any address. Fixtures cover **mainnet, preprod, and preview**.

### Per network
- **script held as a reference script** → strict-equal full response (single UTxO). Response shape mirrors `/addresses/:address/utxos` minus the deprecated `tx_index`.
- **valid script not used as a reference script anywhere** → `[]`
- **unknown script hash** → `404`
- standard pagination error fixtures (`?order/page/count`)

### Stability
The "never spent" requirement matters because the success case is strict-equal. For each network I picked a single reference-script UTxO that is **years old** and sits at a **script address** (not a key address a wallet could spend), so it is effectively permanent:
- preprod `12108…` (2024-02), mainnet `ea153b…` (2023-08), preview `5e26aa…` (2023-06, also exercises a non-null `data_hash`).

### Sourcing / koios cross-check
Each chosen UTxO was cross-checked against koios `/script_utxos` and confirmed to carry the script as its `reference_script` (matching hash + value). Note: koios `/script_utxos` is **address-scoped** (UTxOs locked *at* the script address), so it is not a faithful mirror of this endpoint in general — it only coincides for scripts deployed as a reference script at their own address. The blockfrost endpoint is the source of truth; koios is the cross-check.

This is exactly the gap the request describes: finding a reference input for a script without knowing which address holds it (it could be held at many) — e.g. mainnet's reference UTxOs can sit at arbitrary addresses where an address-based lookup wouldn't find them.

## Verification
- `type-check` + `lint` pass; fixture ids generated via `yarn update-fixtures-ids`.
- All cases (incl. pagination errors) pass against the dev backends for all three networks.