### PR TITLE
fix(allowlist): check whether an allowlist pattern is an _exact_ OpenAPI route

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,23 @@ apiEndpointsKeys.map(path => {
   router.insert(normalizedPath, { pattern: normalizedPath });
 });
 
+// The set of every OpenAPI route, in normalized form. An allowlist entry is only
+// valid if it is byte-for-byte identical (after normalization) to one of these.
+const normalizedApiEndpoints = new Set(apiEndpointsKeys.map(normalizePath));
+
+/**
+ * Checks whether an allowlist pattern is an exact OpenAPI route.
+ */
+export const validateAllowlistPattern = (allowlistPattern: string): string | null => {
+  const normalizedPattern = normalizePath(allowlistPattern);
+
+  if (!normalizedApiEndpoints.has(normalizedPattern)) {
+    return `is not an exact endpoint in the @blockfrost/openapi specification (paths and parameter names must match exactly)`;
+  }
+
+  return null;
+};
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const filePath = path.resolve(__dirname, '../endpoints-allowlist.json');
 const ignorelistFilePath = path.resolve(__dirname, '../endpoints-ignorelist.json');
@@ -45,6 +62,19 @@ try {
   endpointsAllowlist = parsed.map(endpoint => {
     return endpoint.startsWith('/') ? endpoint.slice(1) : endpoint;
   });
+
+  const invalidEntries = endpointsAllowlist
+    .map(entry => ({ entry, error: validateAllowlistPattern(entry) }))
+    .filter((result): result is { entry: string; error: string } => result.error !== null);
+
+  if (invalidEntries.length > 0) {
+    const details = invalidEntries.map(({ entry, error }) => `  - "${entry}": ${error}`).join('\n');
+
+    throw new Error(
+      `endpoints-allowlist.json contains ${invalidEntries.length} invalid entr${invalidEntries.length === 1 ? 'y' : 'ies'} ` +
+        `that would silently match no tests:\n${details}`,
+    );
+  }
 } catch (error) {
   const message = error instanceof Error ? error.message : String(error);
 

--- a/unit/index.test.ts
+++ b/unit/index.test.ts
@@ -173,6 +173,11 @@ describe('validateAllowlistPattern', () => {
   it('rejects a malformed pattern gracefully', () => {
     expect(validateAllowlistPattern('/[invalid][')).not.toBeNull();
   });
+
+  it('ignores query strings and hash fragments, same as URL matching does', () => {
+    expect(validateAllowlistPattern('/blocks/latest?count=5')).toBeNull();
+    expect(validateAllowlistPattern('/accounts/{stake_address}#fragment')).toBeNull();
+  });
 });
 
 const createFixture = (id: string): Fixture => ({

--- a/unit/index.test.ts
+++ b/unit/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isUrlMatch, matchesIgnoreRule } from '../src/index.js';
+import { isUrlMatch, matchesIgnoreRule, validateAllowlistPattern } from '../src/index.js';
 import { Fixture } from '../src/types/index.js';
 
 describe('isUrlMatch', () => {
@@ -134,6 +134,44 @@ describe('isUrlMatch', () => {
   it('matches when both path and pattern have no leading slash', () => {
     expect(isUrlMatch('accounts/stake', 'accounts/{stake_address}')).toBe(true);
     expect(isUrlMatch('blocks/123', 'blocks/{hash_or_number}')).toBe(true);
+  });
+});
+
+describe('validateAllowlistPattern', () => {
+  it('accepts valid parameterized routes', () => {
+    expect(validateAllowlistPattern('/accounts/{stake_address}')).toBeNull();
+    expect(validateAllowlistPattern('/blocks/slot/{slot_number}')).toBeNull();
+    expect(validateAllowlistPattern('/pools/{pool_id}')).toBeNull();
+  });
+
+  it('accepts valid literal routes', () => {
+    expect(validateAllowlistPattern('/health')).toBeNull();
+    expect(validateAllowlistPattern('/blocks/latest')).toBeNull();
+    expect(validateAllowlistPattern('/pools/extended')).toBeNull();
+  });
+
+  it('accepts entries with or without a leading slash', () => {
+    expect(validateAllowlistPattern('accounts/{stake_address}')).toBeNull();
+    expect(validateAllowlistPattern('/accounts/{stake_address}')).toBeNull();
+  });
+
+  it('rejects a route with a mistyped/renamed path parameter', () => {
+    // This is the real-world bug: the spec uses `{slot_number}`, not `{slot}`.
+    // We require an exact match rather than trying to guess the intended route.
+    expect(validateAllowlistPattern('/blocks/slot/{slot}')).not.toBeNull();
+    expect(validateAllowlistPattern('/accounts/{stake}')).not.toBeNull();
+  });
+
+  it('rejects a completely unknown route', () => {
+    expect(validateAllowlistPattern('/this/does/not/exist')).not.toBeNull();
+  });
+
+  it('rejects a route with the wrong number of segments', () => {
+    expect(validateAllowlistPattern('/accounts')).not.toBeNull();
+  });
+
+  it('rejects a malformed pattern gracefully', () => {
+    expect(validateAllowlistPattern('/[invalid][')).not.toBeNull();
   });
 });
 


### PR DESCRIPTION
## Context

Before this, we hit a bug, where an endpoint _looked_ allowed, but it was silently ignored, because the param name didn't match. See:

- https://github.com/blockfrost/blockfrost-platform/pull/598
- https://github.com/blockfrost/blockfrost-platform/commit/8fb22e61a21a0b214eb49a2983c4ef675ab682bc
- https://github.com/blockfrost/blockfrost-platform/pull/598#discussion_r3520522983