### PR TITLE
test: cover assets/:asset/transactions from/to query params

### DIFF
--- a/src/fixtures/mainnet/assets/asset-transactions.ts
+++ b/src/fixtures/mainnet/assets/asset-transactions.ts
@@ -53,6 +53,43 @@ export default [
     ],
   },
   {
+    id: 'assets-asset-transactions-nutcoin-from-to-block-height-range_90422469fb97',
+    testName: 'assets/:asset/transactions - nutcoin from/to block-height range',
+    endpoints: [
+      'assets/00000002df633853f6a47465c9496721d2d5b1291b8398016c0e87ae6e7574636f696e/transactions?from=5602653&to=5616031',
+      'assets/00000002df633853f6a47465c9496721d2d5b1291b8398016c0e87ae6e7574636f696e/transactions?from=5602653&to=5616031&order=asc',
+    ],
+    response: [
+      {
+        tx_hash: 'c38a0892729d071242b89ddd0069eb7c3b6cb0eb7170f040c4b59020b2081a0f',
+        tx_index: 12,
+        block_height: 5_602_653,
+        block_time: 1_618_666_110,
+      },
+      {
+        tx_hash: '09869a301892df7020e0b54a838e53821e304d2fcf64c9aa00902d8bce92a4c3',
+        tx_index: 3,
+        block_height: 5_616_031,
+        block_time: 1_618_938_881,
+      },
+    ],
+  },
+  {
+    id: 'assets-asset-transactions-nutcoin-from-to-block-tx-index-single-pin_76c3a6ec16c2',
+    testName: 'assets/:asset/transactions - nutcoin from/to block:tx_index single-pin',
+    endpoints: [
+      'assets/00000002df633853f6a47465c9496721d2d5b1291b8398016c0e87ae6e7574636f696e/transactions?from=5406748:8&to=5406748:8',
+    ],
+    response: [
+      {
+        tx_hash: 'e252be4c7e40d35919f741c9649ff207c3e49d53bb819e5c1cb458055fd363ed',
+        tx_index: 8,
+        block_height: 5_406_748,
+        block_time: 1_614_635_257,
+      },
+    ],
+  },
+  {
     id: 'assets-asset-transactions-queryparams-all-hail-nutcoin_5eb41ce346b8',
     testName: 'assets/:asset/transactions?queryparams -  all hail nutcoin!',
     endpoints: [

--- a/src/fixtures/preprod/assets/asset-transactions.ts
+++ b/src/fixtures/preprod/assets/asset-transactions.ts
@@ -42,6 +42,43 @@ export default [
     ],
   },
   {
+    id: 'assets-asset-transactions-from-to-block-height-range_a96e1f44bd70',
+    testName: 'assets/:asset/transactions - from/to block-height range',
+    endpoints: [
+      'assets/295ac3ec6d2795c55582f1280e62601afd2d6bc674830112144bd025434f4e54/transactions?from=799974&to=800439',
+      'assets/295ac3ec6d2795c55582f1280e62601afd2d6bc674830112144bd025434f4e54/transactions?from=799974&to=800439&order=asc',
+    ],
+    response: [
+      {
+        tx_hash: '28e0d3e3375090b456625af0156761f3da1c430d04230a1f273086a616638cf0',
+        tx_index: 14,
+        block_height: 799_974,
+        block_time: 1_680_691_366,
+      },
+      {
+        tx_hash: 'cca1fe9acf8ce5eb1e058c6dd2825cf6fc1fa7127ca7876463b0cf3b82a20354',
+        tx_index: 1,
+        block_height: 800_439,
+        block_time: 1_680_702_777,
+      },
+    ],
+  },
+  {
+    id: 'assets-asset-transactions-from-to-block-tx-index-single-pin_89cbb82cdd1e',
+    testName: 'assets/:asset/transactions - from/to block:tx_index single-pin',
+    endpoints: [
+      'assets/295ac3ec6d2795c55582f1280e62601afd2d6bc674830112144bd025434f4e54/transactions?from=800439:1&to=800439:1',
+    ],
+    response: [
+      {
+        tx_hash: 'cca1fe9acf8ce5eb1e058c6dd2825cf6fc1fa7127ca7876463b0cf3b82a20354',
+        tx_index: 1,
+        block_height: 800_439,
+        block_time: 1_680_702_777,
+      },
+    ],
+  },
+  {
     id: 'assets-asset-transactions-queryparams-t-teuro-many-txs_817c9bcb13fd',
     testName: 'assets/:asset/transactions?queryparams -  tTEURO - many txs',
     endpoints: [

--- a/src/fixtures/preview/assets/asset-transactions.ts
+++ b/src/fixtures/preview/assets/asset-transactions.ts
@@ -156,6 +156,49 @@ export default [
     ],
   },
   {
+    id: 'assets-asset-transactions-djed-from-to-block-height-range_a629e5725aea',
+    testName: 'assets/:asset/transactions - DJED from/to block-height range',
+    endpoints: [
+      'assets/7c833f1eb9b70c2e700d028e0ee28d421edad2af4222061be525382d4144415f544544595354414b45315f4c50/transactions?from=1449826&to=1449832',
+      'assets/7c833f1eb9b70c2e700d028e0ee28d421edad2af4222061be525382d4144415f544544595354414b45315f4c50/transactions?from=1449826&to=1449832&order=asc',
+    ],
+    response: [
+      {
+        tx_hash: 'dff7528f4f9306dad36429dde693fec1142f1cc18509bbe65d38bfa4ee15e128',
+        tx_index: 0,
+        block_height: 1_449_826,
+        block_time: 1_700_117_988,
+      },
+      {
+        tx_hash: 'ec544bff35f1045132cd92e9ae73e6a4333aa1729f029369898e240994028dc6',
+        tx_index: 0,
+        block_height: 1_449_831,
+        block_time: 1_700_118_109,
+      },
+      {
+        tx_hash: 'f5c1de2e622d0327d8f3e9229ac3c8a0f01bb9720389d59d78cfe957dfff8ddd',
+        tx_index: 0,
+        block_height: 1_449_832,
+        block_time: 1_700_118_197,
+      },
+    ],
+  },
+  {
+    id: 'assets-asset-transactions-djed-from-to-block-tx-index-single-pin_1678f222112c',
+    testName: 'assets/:asset/transactions - DJED from/to block:tx_index single-pin',
+    endpoints: [
+      'assets/7c833f1eb9b70c2e700d028e0ee28d421edad2af4222061be525382d4144415f544544595354414b45315f4c50/transactions?from=1449809:1&to=1449809:1',
+    ],
+    response: [
+      {
+        tx_hash: '44c572ccad7ac911bdaf0a46ce3758ccf5da408b79ce896b1dd2a31cb1c1c57d',
+        tx_index: 1,
+        block_height: 1_449_809,
+        block_time: 1_700_117_698,
+      },
+    ],
+  },
+  {
     id: 'assets-asset-transactions-djed-desc_716b44e3e2ad',
     testName: 'assets/:asset/transactions - DJED desc',
     endpoints: [


### PR DESCRIPTION
## Summary
- Adds two fixtures per network (mainnet, preprod, preview) for `assets/{asset}/transactions?from=…&to=…`, which the API supports and validates but the suite did not cover.
- Range fixture uses two endpoint variants (`&order=asc` too) so it also pins the interaction between `from/to` and `order`.
- Single-pin fixture exercises the `block:tx_index` shape (`from=X:i&to=X:i`).

Assets are reused from existing fixtures (nutcoin on mainnet, `295ac3ec…434f4e54` on preprod, DJED-like on preview) — no new chain-state dependencies.

Verified against the live public API before committing:

```
GET /assets/{asset}/transactions?from=799974&to=800439           → 2 txs (preprod)
GET /assets/{asset}/transactions?from=800439:1&to=800439:1       → 1 tx  (preprod)
GET /assets/{asset}/transactions?from=5602653&to=5616031         → 2 txs (mainnet)
GET /assets/{asset}/transactions?from=5406748:8&to=5406748:8     → 1 tx  (mainnet)
GET /assets/{asset}/transactions?from=1449826&to=1449832         → 3 txs (preview)
GET /assets/{asset}/transactions?from=1449809:1&to=1449809:1     → 1 tx  (preview)
```

## Test plan
- [ ] `yarn tsc --noEmit` passes (verified locally)
- [ ] `yarn check-fixture-wiring` passes (verified locally)
- [ ] CI green on the three per-network integration jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)