### PR TITLE
test: cover account dereg + re-reg in the same transaction

### DIFF
--- a/src/fixtures/mainnet/accounts/stake-address.ts
+++ b/src/fixtures/mainnet/accounts/stake-address.ts
@@ -27,6 +27,27 @@ export default [
     },
   },
   {
+    id: 'accounts-stake-address-deregistered-and-re-registered-in-the-same-tx_6a6b8cbb4983',
+    testName: 'accounts/:stake_address - deregistered and re-registered in the same tx',
+    endpoints: ['accounts/stake1u80m3f9xx9pld4tjlh6pr9vgn5a5nn08tkf86ump5h6z7zcswtsex'],
+    response: {
+      stake_address: 'stake1u80m3f9xx9pld4tjlh6pr9vgn5a5nn08tkf86ump5h6z7zcswtsex',
+      // dereg + re-reg + delegation certs in one tx apply in cert_index
+      // order, so the final state is registered and delegated
+      active: true,
+      registered: true,
+      active_epoch: 373,
+      controlled_amount: expect.toBeGreaterThanOrEqual('2452953'),
+      rewards_sum: expect.toBeGreaterThanOrEqual('145141'),
+      withdrawals_sum: '0',
+      drep_id: null,
+      reserves_sum: '0',
+      treasury_sum: '0',
+      withdrawable_amount: expect.toBeGreaterThanOrEqual('145141'),
+      pool_id: 'pool1m3h5p82m6v99nda37rmed8vrkqt43e2a8d89k76gw5ets0gdyag',
+    },
+  },
+  {
     id: 'accounts-stake-address-generic-stake-address-1-case_37b4c7d97926',
     testName: 'accounts/:stake_address generic stake address 1. case',
     endpoints: ['accounts/stake1u9fzg77vrgfqlplkjqe9hntdcvsurpvxd60yp2fhn73002qsv9pdk'],

--- a/src/fixtures/preprod/accounts/stake-address.ts
+++ b/src/fixtures/preprod/accounts/stake-address.ts
@@ -46,6 +46,27 @@ export default [
     },
   },
   {
+    id: 'accounts-stake-address-deregistered-and-re-registered-in-the-same-tx_f522d2652cd5',
+    testName: 'accounts/:stake_address - deregistered and re-registered in the same tx',
+    endpoints: ['accounts/stake_test1upssxqqvnx3wrc4n67p4jsgfvmams7jym9t3w2ha6mzvpfgmxv6vg'],
+    response: {
+      stake_address: 'stake_test1upssxqqvnx3wrc4n67p4jsgfvmams7jym9t3w2ha6mzvpfgmxv6vg',
+      active: false,
+      // dereg (cert_index 0) + re-reg (cert_index 1) in tx 918d77f3... apply
+      // in ledger order, so the final state is registered
+      registered: true,
+      active_epoch: expect.toBeEpochNumber(),
+      controlled_amount: expect.toBeAdaQuantity(),
+      rewards_sum: expect.toBeAdaQuantity(),
+      withdrawals_sum: expect.toBeAdaQuantity(),
+      reserves_sum: '0',
+      treasury_sum: '0',
+      withdrawable_amount: expect.toBeAdaQuantity(),
+      pool_id: null,
+      drep_id: null,
+    },
+  },
+  {
     id: 'accounts-stake-address-generic-stake-address_14356bed4860',
     testName: 'accounts/:stake_address generic stake address',
     endpoints: ['accounts/stake_test1uplm3vtt2637738tx4wy9l4sjlhtdld2nvtlv8pj9ng9feg6d3pr7'],


### PR DESCRIPTION
Adds a preprod `/accounts/:stake_address` regression test for [blockfrost-backend-ryo#349](https://github.com/blockfrost/blockfrost-backend-ryo/issues/349): account `stake_test1upssxqqvnx3wrc4n67p4jsgfvmams7jym9t3w2ha6mzvpfgmxv6vg` deregistered (cert_index 0) and re-registered (cert_index 1) in the same transaction ([918d77f3…](https://preprod.cardanoscan.io/transaction/918d77f347dbbee6218e7f2ec04a6cdab5c4573bfae118a6ae36fa063ba56be6)), so its final ledger state is **registered** (confirmed independently via Koios `account_info`).

Volatile amounts use matchers; the pinned assertions are the certificate-ordering semantics: `registered: true`, `active: false`, `pool_id: null`.

⚠️ This test fails against currently deployed backends — it passes once the fix from [blockfrost-backend-ryo#350](https://github.com/blockfrost/blockfrost-backend-ryo/pull/350) (6.7.2) is released and deployed, so merge after the backend rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)